### PR TITLE
fix(tool): fix a compatibility issue of `globby` in Windows.

### DIFF
--- a/tool/md2json.js
+++ b/tool/md2json.js
@@ -6,7 +6,8 @@ const htmlparser2 = require('htmlparser2');
 const chalk = require('chalk');
 
 async function convert(opts) {
-    const mdPath = opts.path;
+    // globby does not support '\' yet
+    const mdPath = opts.path.replace(/\\/g, '/');
     const sectionsAnyOf = opts.sectionsAnyOf;
     const entry = opts.entry;
     const tplEnv = opts.tplEnv;


### PR DESCRIPTION
Like apache/incubator-echarts#13629, `globby` does not support `'\'` yet.
It can't scan files if the path pattern contains `'\'` in Windows.

So `npm run watch` cannot run.
```js
TypeError: etplEngine.getRenderer(...) is not a function
    at convert (C:\echarts\echarts-doc\tool\md2json.js:57:46)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)\
```

In the meanwhile, please help to check if it works well in macOS.

Thanks!