### PR TITLE
chore: make dataZoom example simpler

### DIFF
--- a/zh/option/component/data-zoom-inside.md
+++ b/zh/option/component/data-zoom-inside.md
@@ -36,12 +36,10 @@ const option = {
             show: false
         }
     },
-    dataZoom: [{
+    dataZoom: {
         start: 80,
         type: 'inside'
-    }, {
-        start: 80
-    }],
+    },
     series: {
         name: 'Beijing AQI',
         type: 'bar',


### PR DESCRIPTION
Original issue was https://github.com/apache/echarts/issues/14018

and `zoomLock` on [dataZoom-inside.zoomLock ](https://echarts.apache.org/next/zh/option.html#dataZoom-inside.zoomLock) not work as expect since one of `dataZoom` array item is missing `zoomLock`