### PR TITLE
fix: modify typescript tree-shaking tutorial code

### DIFF
--- a/en/tutorial/tree-shaking.md
+++ b/en/tutorial/tree-shaking.md
@@ -101,9 +101,14 @@ import {
 } from 'echarts/renderers';
 
 // Combine an Option type with only required components and charts via ComposeOption
-type ECOption = echarts.
+type ECOption = echarts.ComposeOption<
   BarSeriesOption | LineSeriesOption | TitleComponentOption | GridComponentOption
 >;
+
+// Register the required components
+echarts.use(
+    [TitleComponent, TooltipComponent, GridComponent, BarChart, CanvasRenderer]
+);
 
 var option: ECOption = {
     ...

--- a/zh/tutorial/tree-shaking.md
+++ b/zh/tutorial/tree-shaking.md
@@ -105,6 +105,11 @@ type ECOption = echarts.ComposeOption<
   BarSeriesOption | LineSeriesOption | TitleComponentOption | GridComponentOption
 >;
 
+// 注册必须的组件
+echarts.use(
+    [TitleComponent, TooltipComponent, GridComponent, BarChart, CanvasRenderer]
+);
+
 var option: ECOption = {
     ...
 }


### PR DESCRIPTION
There is a little typo in English version of typescript tree-shaking code.
And I added several lines of code of typecript tree-shaking for a clear guidance.