### PR TITLE
Add `useDirtyRect` feature in API doc and etc

### DIFF
--- a/en/api/echarts.md
+++ b/en/api/echarts.md
@@ -8,6 +8,7 @@ Global echarts object, which can be accessed after including `echarts.js` in scr
 (dom: HTMLDivElement|HTMLCanvasElement, theme?: Object|string, opts?: {
     devicePixelRatio?: number,
     renderer?: string,
+    useDirtyRect?: boolean, // Since `5.0.0`
     width?: number|string,
     height?: number|string,
     locale?: string
@@ -26,7 +27,7 @@ Creates an ECharts instance, and returns an [echartsInstance](~echartsInstance).
 
 + `theme`
 
-    Theme to be applied. This can be a configuring object of a theme, or a theme name registered through [echarts.registerTheme](~echarts.registerTheme).
+    Theme to be applied. This can be a configuring object of a theme, or a theme name registered through [echarts.registerTheme](~echarts.registerTheme). See [Overview of Style Customization](https://echarts.apache.org/en/tutorial.html#Overview%20of%20Style%20Customization).
 
 + `opts`
 
@@ -34,9 +35,15 @@ Creates an ECharts instance, and returns an [echartsInstance](~echartsInstance).
 
     + `devicePixelRatio` Ratio of one physical pixel to the size of one device independent pixels. Browser's `window.devicePixelRatio` is used by default.
     + `renderer`  Supports `'canvas'` or `'svg'`. See [Render by Canvas or SVG](tutorial.html#Render%20by%20Canvas%20or%20SVG).
+    + `useDirtyRect`  Enable dirty rectangle rendering or not, `false` by default. See [New features in ECharts 5](https://echarts.apache.org/en/tutorial.html#New%20features%20in%20ECharts%205).
     + `width`  Specify width explicitly, in pixel. If setting to `null`/`undefined`/`'auto'`, width of `dom` (instance container) will be used.
     + `height`  Specify height explicitly, in pixel. If setting to `null`/`undefined`/`'auto'`, height of `dom` (instance container) will be used.
-    + `locale` Specify the locale. There are two builtins: `'ZH'` and `'EN'`. Or you can use [echarts.registerLocale](~echarts.registerLocale) to register a new locale. Or supported locales can be referenced in [src/i18n](https://github.com/apache/echarts/tree/release/src/i18n)
+    + `locale` Specify the locale. There are two builtins: `'ZH'` and `'EN'`. Or you can use [echarts.registerLocale](~echarts.registerLocale) to register a new locale. Or supported locales can be referenced in [src/i18n](https://github.com/apache/echarts/tree/release/src/i18n).
+
+    If no need to specify a theme, a `null` should be passed before `opts` . Example:
+    ```js
+    const chart = echarts.init(dom, null, {renderer: 'svg'});
+    ```
 
 ## connect(Function)
 ```js

--- a/zh/api/echarts.md
+++ b/zh/api/echarts.md
@@ -8,6 +8,7 @@
 (dom: HTMLDivElement|HTMLCanvasElement, theme?: Object|string, opts?: {
     devicePixelRatio?: number,
     renderer?: string,
+    useDirtyRect?: boolean, // 从 `v5.0.0` 开始支持
     width?: number|string,
     height?: number|string,
     locale?: string
@@ -26,7 +27,7 @@
 
 + `theme`
 
-    应用的主题。可以是一个主题的配置对象，也可以是使用已经通过 [echarts.registerTheme](~echarts.registerTheme) 注册的主题名称。
+    应用的主题。可以是一个主题的配置对象，也可以是使用已经通过 [echarts.registerTheme](~echarts.registerTheme) 注册的主题名称。参见 [ECharts 中的样式简介](https://echarts.apache.org/zh/tutorial.html#ECharts%20%E4%B8%AD%E7%9A%84%E6%A0%B7%E5%BC%8F%E7%AE%80%E4%BB%8B)。
 
 + `opts`
 
@@ -34,9 +35,15 @@
 
     + `devicePixelRatio` 设备像素比，默认取浏览器的值`window.devicePixelRatio`。
     + `renderer` 渲染器，支持 `'canvas'` 或者 `'svg'`。参见 [使用 Canvas 或者 SVG 渲染](tutorial.html#%E4%BD%BF%E7%94%A8%20Canvas%20%E6%88%96%E8%80%85%20SVG%20%E6%B8%B2%E6%9F%93)。
+    + `useDirtyRect` 是否开启脏矩形渲染，默认为`false`。参见 [ECharts 5 新特性](https://echarts.apache.org/zh/tutorial.html#ECharts%205%20%E6%96%B0%E7%89%B9%E6%80%A7)。
     + `width` 可显式指定实例宽度，单位为像素。如果传入值为 `null`/`undefined`/`'auto'`，则表示自动取 `dom`（实例容器）的宽度。
     + `height` 可显式指定实例高度，单位为像素。如果传入值为 `null`/`undefined`/`'auto'`，则表示自动取 `dom`（实例容器）的高度。
-    + `locale` 使用的语言，内置 `'ZH'` 和 `'EN'` 两个语言，也可以使用 [echarts.registerLocale](~echarts.registerLocale) 方法注册新的语言包。目前支持的语言见 [src/i18n](https://github.com/apache/echarts/tree/release/src/i18n)
+    + `locale` 使用的语言，内置 `'ZH'` 和 `'EN'` 两个语言，也可以使用 [echarts.registerLocale](~echarts.registerLocale) 方法注册新的语言包。目前支持的语言见 [src/i18n](https://github.com/apache/echarts/tree/release/src/i18n)。
+
+    如果不指定主题，也需在传入`opts`前先传入`null`，如：
+    ```js
+    const chart = echarts.init(dom, null, {renderer: 'svg'});
+    ```
 
 
 ## connect(Function)


### PR DESCRIPTION
1. Add `useDirtyRect` feature in API doc.
2. Add a notice that when calling `echarts.init` with `opts`, a `null` should also be passed if no need to specify a theme.
3. Add a reference link for `theme` in echarts.init().