### PR TITLE
fix(axisLabel.formatter): example variable name

### DIFF
--- a/en/option/component/axis-common.md
+++ b/en/option/component/axis-common.md
@@ -798,7 +798,7 @@ formatter: function (value, index) {
     // Formatted to be month/day; display year only in the first label
     var date = new Date(value);
     var texts = [(date.getMonth() + 1), date.getDate()];
-    if (idx === 0) {
+    if (index === 0) {
         texts.unshift(date.getYear());
     }
     return texts.join('/');


### PR DESCRIPTION
I noticed one of the examples uses the wrong parameter name: `idx` instead of `index`.

This example function is correct in the [zh translation](https://github.com/apache/echarts-doc/blob/master/zh/option/component/axis-common.md).

Thanks for this lib and its awesome documentation!