### PR TITLE
chore: refine sankey line style color

### DIFF
--- a/en/option/series/sankey.md
+++ b/en/option/series/sankey.md
@@ -190,7 +190,7 @@ The style of node rectangle in Sankey diagram.
 
 ## lineStyle(Object)
 
-The edge style of Sankey diagram, in which [lineStyle.color](~series-sankey.lineStyle.color) can be assigned to the value of `'source'` of `'target'`, then the edge will automatically take the source node or target node color as its own color.
+The edge style of Sankey diagram
 
 {{ use: partial-sankey-line-style(
     prefix = "##"
@@ -404,6 +404,10 @@ Equals to [links](~series-sankey.links)
 #${prefix} color(Color) = "'#314656'"
 
 The color of the edge in Sankey diagram.
+
++ `'source'`: use source node color.
++ `'target'`: use target node color.
++ `'gradient'`: gradient color between source node and target node (supported in 5.0).
 
 #${prefix} opacity(number) = 0.2
 

--- a/zh/option/series/sankey.md
+++ b/zh/option/series/sankey.md
@@ -193,9 +193,7 @@ levels: [{
 
 ## lineStyle(Object)
 
-桑基图边的样式，其中 [lineStyle.color](~series-sankey.lineStyle.color) 支持设置为`'source'`或者`'target'`特殊值，此时边会自动取源节点或目标节点的颜色作为自己的颜色。
-
-从 5.0 开始, [lineStyle.color](~series-sankey.lineStyle.color) 还可以设置为`'gradient'`，取从源节点到目标节点的渐变色。
+桑基图边的样式
 
 {{ use: partial-sankey-line-style(
     prefix = "##"
@@ -409,6 +407,10 @@ links: [{
 #${prefix} color(Color) = '#314656'
 
 桑基图边的颜色。
+
++ `'source'`: 使用源节点颜色。
++ `'target'`: 使用目标节点颜色。
++ `'gradient'`: 以源节点和目标节点的颜色做一个渐变过度色。(5.0开始支持)
 
 #${prefix} opacity(number) = 0.2
 


### PR DESCRIPTION
Move `sankey.lineStyle.color`  to more appropriate place.