### PR TITLE
series.scatter selectedMode disabled by default

### DIFF
--- a/en/option/partial/selected-mode.md
+++ b/en/option/partial/selected-mode.md
@@ -11,7 +11,4 @@
 
 <ExampleUIControlEnum options="false,true,single,multiple" />
 
-Selected mode.  It is enabled by default, and you may set it to be `false` to disabled it.
-
-Besides, it can be set to `'single'` or `'multiple'`, for single selection and multiple selections.
-
+The selected mode is disabled by default. The default value is `false`. The configuration of the selected mode indicates whether single, multiple, or no selections are supported. It supports boolean values and strings. The string values can be set to `'single'` for single selection support or to `'multiple'` for multiple selection support.


### PR DESCRIPTION
The docs say that the default for series.scatter `selectedMode` is "enabled". The default based on my use appears to be "disabled". 
This PR updates the docs to match the functionality of echarts.