### PR TITLE
docs: add size option for dataZoom-slider

### DIFF
--- a/en/option/component/data-zoom-slider.md
+++ b/en/option/component/data-zoom-slider.md
@@ -213,21 +213,25 @@ Whether to update view while dragging. If it is set as `false`, the view will be
     dataZoomName = 'dataZoom-slider'
 ) }}
 
-## width(string|number) = 30
+{{ use: partial-rect-layout(
+    componentName = 'dataZoom-slider'
+) }}
+
+## width(string|number)
 
 <ExampleUIControlNumber default="30"/>
 
 Width of dataZoom-slider component. Default to 30 when vertical, adaptive when horizontal.
 
-## height(string|number) = 30
+Has higer priority than `left` and `right`.
+
+## height(string|number)
 
 <ExampleUIControlNumber default="30"/>
 
 Height of dataZoom-slider component. Default to 30 when horizontal, adaptive when vertical.
 
-{{ use: partial-rect-layout(
-    componentName = 'dataZoom-slider'
-) }}
+Has higer priority than `top` and `bottom`.
 
 ## brushSelect(boolean) = true
 

--- a/en/option/component/data-zoom-slider.md
+++ b/en/option/component/data-zoom-slider.md
@@ -213,6 +213,18 @@ Whether to update view while dragging. If it is set as `false`, the view will be
     dataZoomName = 'dataZoom-slider'
 ) }}
 
+## width(string|number) = 30
+
+<ExampleUIControlNumber default="30"/>
+
+Width of dataZoom-slider component. Default to 30 when vertical, adaptive when horizontal.
+
+## height(string|number) = 30
+
+<ExampleUIControlNumber default="30"/>
+
+Height of dataZoom-slider component. Default to 30 when horizontal, adaptive when vertical.
+
 {{ use: partial-rect-layout(
     componentName = 'dataZoom-slider'
 ) }}

--- a/zh/option/component/data-zoom-slider.md
+++ b/zh/option/component/data-zoom-slider.md
@@ -243,21 +243,25 @@ labelFormatter: function (value) {
     dataZoomName = 'dataZoom-slider'
 ) }}
 
-## width(string|number) = 30
+{{ use: partial-rect-layout(
+    componentName = 'dataZoom-slider'
+) }}
+
+## width(string|number)
 
 <ExampleUIControlNumber default="30"/>
 
 dataZoom-slider 组件的宽度。竖直布局默认 30，水平布局默认自适应。
 
-## height(string|number) = 30
+比 `left` 和 `right` 优先级高。
+
+## height(string|number)
 
 <ExampleUIControlNumber default="30"/>
 
 dataZoom-slider 组件的高度。水平布局默认 30，竖直布局默认自适应。
 
-{{ use: partial-rect-layout(
-    componentName = 'dataZoom-slider'
-) }}
+比 `top` 和 `bottom` 优先级高。
 
 ## brushSelect(boolean) = true
 

--- a/zh/option/component/data-zoom-slider.md
+++ b/zh/option/component/data-zoom-slider.md
@@ -243,6 +243,18 @@ labelFormatter: function (value) {
     dataZoomName = 'dataZoom-slider'
 ) }}
 
+## width(string|number) = 30
+
+<ExampleUIControlNumber default="30"/>
+
+dataZoom-slider 组件的宽度。竖直布局默认 30，水平布局默认自适应。
+
+## height(string|number) = 30
+
+<ExampleUIControlNumber default="30"/>
+
+dataZoom-slider 组件的高度。水平布局默认 30，竖直布局默认自适应。
+
 {{ use: partial-rect-layout(
     componentName = 'dataZoom-slider'
 ) }}


### PR DESCRIPTION
According to source code, we could set size of dataZoom-slider.

https://github.com/apache/echarts/blob/4a8a7f58e772586eebfbb080d2d14f5ded5478c0/src/component/dataZoom/SliderZoomView.ts#L245