### PR TITLE
fix(radar): radar.name is deprecated

### DIFF
--- a/en/option/component/radar.md
+++ b/en/option/component/radar.md
@@ -26,7 +26,7 @@ The start angle of coordinate, which is the angle of the first indicator axis.
 
 ## axisName(Object)
 
-Name of radar chart.
+Name options for radar indicators.
 
 ### show(boolean) = true
 

--- a/en/option/component/radar.md
+++ b/en/option/component/radar.md
@@ -24,7 +24,7 @@ Here is a custom example of radar component.
 
 The start angle of coordinate, which is the angle of the first indicator axis.
 
-## name(Object)
+## axisName(Object)
 
 Name of radar chart.
 

--- a/zh/option/component/radar.md
+++ b/zh/option/component/radar.md
@@ -60,7 +60,7 @@ const option = {
 
 坐标系起始角度，也就是第一个指示器轴的角度。
 
-## name(Object)
+## axisName(Object)
 
 雷达图每个指示器名称的配置项。
 


### PR DESCRIPTION
According to [compatStyle.ts#L295](https://github.com/apache/echarts/blob/c2cdc02d6f5f2436104061f97236b4f182625231/src/preprocessor/helper/compatStyle.ts#L295), `radar.name` is deprecated and should use `radar.axisName` instead. 

Tested and confirmed that either of the options works.