### PR TITLE
fix: dafault value of treemap.label.padding

### DIFF
--- a/en/option/partial/label.md
+++ b/en/option/partial/label.md
@@ -69,6 +69,7 @@ Whether to move text slightly. For example: `[30, 40]` means move `30` horizonta
     noVerticalAlign = ${noVerticalAlign},
     name = ${name},
     defaultColor = ${defaultColor},
+    defaultPadding = ${defaultPadding},
     defaultFontSize = ${defaultFontSize},
     noRich = ${noRich},
     noBox = ${noBox},

--- a/en/option/partial/text-style.md
+++ b/en/option/partial/text-style.md
@@ -22,6 +22,7 @@
     prefix = ${prefix},
     name = ${name},
     defaultColor = ${defaultColor},
+    defaultPadding = ${defaultPadding},
     defaultFontSize = ${defaultFontSize},
     defaultFontWeight = ${defaultFontWeight},
     defaultLineHeight = ${defaultLineHeight},
@@ -273,7 +274,7 @@ Border width of the text fragment.
 
 Border radius of the text fragment.
 
-#${prefix} padding(number|Array) = 0
+#${prefix} padding(number|Array) = ${defaultPadding|default(0)}
 
 <ExampleUIControlVector min="0" dims="T,R,B,L"  />
 

--- a/en/option/series/treemap.md
+++ b/en/option/series/treemap.md
@@ -558,6 +558,7 @@ This can hide the details of nodes when the rectangular area is not large enough
 
 {{ use: partial-label(
     prefix = ${prefix} + "#",
+    defaultPadding = 5,
     defaultPosition = "'inside'",
     formatter = true
 ) }}

--- a/zh/option/partial/label.md
+++ b/zh/option/partial/label.md
@@ -69,6 +69,7 @@ ${name}图形上的文本标签，可用于说明图形的一些数据信息，�
     noVerticalAlign = ${noVerticalAlign},
     name = ${name},
     defaultColor = ${defaultColor},
+    defaultPadding = ${defaultPadding},
     defaultFontSize = ${defaultFontSize},
     noRich = ${noRich},
     noBox = ${noBox},

--- a/zh/option/partial/text-style.md
+++ b/zh/option/partial/text-style.md
@@ -22,6 +22,7 @@
     prefix = ${prefix},
     name = ${name},
     defaultColor = ${defaultColor},
+    defaultPadding = ${defaultPadding},
     defaultFontSize = ${defaultFontSize},
     defaultFontWeight = ${defaultFontWeight},
     defaultLineHeight = ${defaultLineHeight},
@@ -274,7 +275,7 @@ backgroundColor: {
 
 文字块的圆角。
 
-#${prefix} padding(number|Array) = 0
+#${prefix} padding(number|Array) = ${defaultPadding|default(0)}
 
 <ExampleUIControlVector min="0" dims="T,R,B,L"  />
 

--- a/zh/option/series/treemap.md
+++ b/zh/option/series/treemap.md
@@ -700,6 +700,7 @@ treemap 默认把第一个维度（Array 第一项）映射到『面积』上。
 
 {{ use: partial-label(
     prefix = ${prefix} + "#",
+    defaultPadding = 5,
     defaultPosition = "'inside'",
     formatter = true
 ) }}


### PR DESCRIPTION
The default value of `series-treemap.label.padding` should be `5` according to [TreemapSeries.ts](https://github.com/apache/echarts/blob/6d68a7dadbd73ff79831d819e014e859f8b2241a/src/chart/treemap/TreemapSeries.ts#L275) but it's `0` in the current doc.