### PR TITLE
doc: use single quotes

### DIFF
--- a/en/option/partial/animation.md
+++ b/en/option/partial/animation.md
@@ -31,7 +31,7 @@ animationDurationUpdate: function (idx) {
 }
 ```
 
-#${prefix} animationEasingUpdate(string) = ${defaultAnimationEasingUpdate|default('cubicOut')}
+#${prefix} animationEasingUpdate(string) = ${defaultAnimationEasingUpdate|default("'cubicOut'")}
 
 <ExampleUIControlEnum options="linear,quadraticIn,quadraticOut,quadraticInOut,cubicIn,cubicOut,cubicInOut,quarticIn,quarticOut,quarticInOut,quinticIn,quinticOut,quinticInOut,sinusoidalIn,sinusoidalOut,sinusoidalInOut,exponentialIn,exponentialOut,exponentialInOut,circularIn,circularOut,circularInOut,elasticIn,elasticOut,elasticInOut,backIn,backOut,backInOut,bounceIn,bounceOut,bounceInOut" />
 
@@ -70,7 +70,7 @@ animationDuration: function (idx) {
 }
 ```
 
-#${prefix} animationEasing(string) = ${defaultAnimationEasing|default('cubicOut')}
+#${prefix} animationEasing(string) = ${defaultAnimationEasing|default("'cubicOut'")}
 
 <ExampleUIControlEnum options="linear,quadraticIn,quadraticOut,quadraticInOut,cubicIn,cubicOut,cubicInOut,quarticIn,quarticOut,quarticInOut,quinticIn,quinticOut,quinticInOut,sinusoidalIn,sinusoidalOut,sinusoidalInOut,exponentialIn,exponentialOut,exponentialInOut,circularIn,circularOut,circularInOut,elasticIn,elasticOut,elasticInOut,backIn,backOut,backInOut,bounceIn,bounceOut,bounceInOut" clean="true" />
 

--- a/en/option/partial/line-border-style.md
+++ b/en/option/partial/line-border-style.md
@@ -71,9 +71,9 @@ Refer to MDN [lineDashOffset](https://developer.mozilla.org/en-US/docs/Web/API/C
 
 {{ if: !${noCap} }}
 {{ if: ${type} === 'border' }}
-#${prefix} borderCap(string) = ${defaultCap|default('butt')}
+#${prefix} borderCap(string) = ${defaultCap|default("'butt'")}
 {{ else }}
-#${prefix} cap(string) = ${defaultCap|default('butt')}
+#${prefix} cap(string) = ${defaultCap|default("'butt'")}
 {{ /if }}
 
 {{ use: partial-version(
@@ -93,9 +93,9 @@ Default value is `'butt'`. Refer to MDN [lineCap](https://developer.mozilla.org/
 
 {{ if: !${noJoin} }}
 {{ if: ${type} === 'border' }}
-#${prefix} borderJoin(string) = ${defaultJoin|default('bevel')}
+#${prefix} borderJoin(string) = ${defaultJoin|default("'bevel'")}
 {{ else }}
-#${prefix} join(string) = ${defaultJoin|default('bevel')}
+#${prefix} join(string) = ${defaultJoin|default("'bevel'")}
 {{ /if }}
 
 {{ use: partial-version(

--- a/en/option/partial/progressive.md
+++ b/en/option/partial/progressive.md
@@ -14,7 +14,7 @@ Set `progressive: 0` to disable progressive permanently. By default, progressive
 If current data amount is over the threshold, "progressive rendering" is enabled.
 
 {{ if: ${supportProgressiveChunkMode} }}
-#${prefix} progressiveChunkMode(string) = ${defaultProgressiveChunkMode|default('sequential')}
+#${prefix} progressiveChunkMode(string) = ${defaultProgressiveChunkMode|default("'sequential'")}
 
 Chunk approach, optional values:
 + `'sequential'`: slice data by data index.

--- a/en/option/partial/text-style.md
+++ b/en/option/partial/text-style.md
@@ -119,7 +119,7 @@ For more details, see [Rich Text](tutorial.html#Rich%20Text) please.
 
 {{ target: partial-text-style-base-item }}
 
-#${prefix} color(Color) = ${defaultColor|default('"#fff"')}
+#${prefix} color(Color) = ${defaultColor|default("'#fff'")}
 
 <ExampleUIControlColor default="${defaultColor|default(null)}" />
 
@@ -140,7 +140,7 @@ Options are:
 + `'italic'`
 + `'oblique'`
 
-#${prefix} fontWeight(string|number) = ${defaultFontWeight|default('normal')}
+#${prefix} fontWeight(string|number) = ${defaultFontWeight|default("'normal'")}
 
 <ExampleUIControlEnum default="normal" options="normal,bold,bolder,lighter" />
 

--- a/en/option/series/bar.md
+++ b/en/option/series/bar.md
@@ -352,7 +352,7 @@ Rectangle style configurations of single data.
 
 {{ target: partial-bar-item-style }}
 
-#${prefix} color(Color) = ${defaultColor|default('auto')}
+#${prefix} color(Color) = ${defaultColor|default("'auto'")}
 
 <ExampleUIControlColor />
 

--- a/zh/option/partial/animation.md
+++ b/zh/option/partial/animation.md
@@ -33,7 +33,7 @@ animationDurationUpdate: function (idx) {
 }
 ```
 
-#${prefix} animationEasingUpdate(string) = ${defaultAnimationEasingUpdate|default('cubicInOut')}
+#${prefix} animationEasingUpdate(string) = ${defaultAnimationEasingUpdate|default("'cubicInOut'")}
 
 <ExampleUIControlEnum options="linear,quadraticIn,quadraticOut,quadraticInOut,cubicIn,cubicOut,cubicInOut,quarticIn,quarticOut,quarticInOut,quinticIn,quinticOut,quinticInOut,sinusoidalIn,sinusoidalOut,sinusoidalInOut,exponentialIn,exponentialOut,exponentialInOut,circularIn,circularOut,circularInOut,elasticIn,elasticOut,elasticInOut,backIn,backOut,backInOut,bounceIn,bounceOut,bounceInOut" />
 
@@ -72,7 +72,7 @@ animationDuration: function (idx) {
 }
 ```
 
-#${prefix} animationEasing(string) = ${defaultAnimationEasing|default('cubicOut')}
+#${prefix} animationEasing(string) = ${defaultAnimationEasing|default("'cubicOut'")}
 
 <ExampleUIControlEnum options="linear,quadraticIn,quadraticOut,quadraticInOut,cubicIn,cubicOut,cubicInOut,quarticIn,quarticOut,quarticInOut,quinticIn,quinticOut,quinticInOut,sinusoidalIn,sinusoidalOut,sinusoidalInOut,exponentialIn,exponentialOut,exponentialInOut,circularIn,circularOut,circularInOut,elasticIn,elasticOut,elasticInOut,backIn,backOut,backInOut,bounceIn,bounceOut,bounceInOut" clean="true" />
 

--- a/zh/option/partial/line-border-style.md
+++ b/zh/option/partial/line-border-style.md
@@ -71,9 +71,9 @@ ${name}描边类型。
 
 {{ if: !${noCap} }}
 {{ if: ${type} === 'border' }}
-#${prefix} borderCap(string) = ${defaultCap|default('butt')}
+#${prefix} borderCap(string) = ${defaultCap|default("'butt'")}
 {{ else }}
-#${prefix} cap(string) = ${defaultCap|default('butt')}
+#${prefix} cap(string) = ${defaultCap|default("'butt'")}
 {{ /if }}
 
 {{ use: partial-version(
@@ -92,9 +92,9 @@ ${name}描边类型。
 
 {{ if: !${noJoin} }}
 {{ if: ${type} === 'border' }}
-#${prefix} borderJoin(string) = ${defaultJoin|default('bevel')}
+#${prefix} borderJoin(string) = ${defaultJoin|default("'bevel'")}
 {{ else }}
-#${prefix} join(string) = ${defaultJoin|default('bevel')}
+#${prefix} join(string) = ${defaultJoin|default("'bevel'")}
 {{ /if }}
 
 {{ use: partial-version(

--- a/zh/option/partial/progressive.md
+++ b/zh/option/partial/progressive.md
@@ -15,7 +15,7 @@
 启用渐进式渲染的图形数量阈值，在单个系列的图形数量超过该阈值时启用渐进式渲染。
 
 {{ if: ${supportProgressiveChunkMode} }}
-#${prefix} progressiveChunkMode(string) = ${defaultProgressiveChunkMode|default('sequential')}
+#${prefix} progressiveChunkMode(string) = ${defaultProgressiveChunkMode|default("'sequential'")}
 
 分片的方式。可选值：
 + `'sequential'`: 按照数据的顺序分片。缺点是渲染过程不自然。

--- a/zh/option/partial/text-style.md
+++ b/zh/option/partial/text-style.md
@@ -121,7 +121,7 @@ label: {
 
 {{ target: partial-text-style-base-item }}
 
-#${prefix} color(Color) = ${defaultColor|default('"#fff"')}
+#${prefix} color(Color) = ${defaultColor|default("'#fff'")}
 
 <ExampleUIControlColor default="${defaultColor|default(null)}" />
 
@@ -142,7 +142,7 @@ ${name}文字字体的风格。
 + `'italic'`
 + `'oblique'`
 
-#${prefix} fontWeight(string|number) = ${defaultFontWeight|default('normal')}
+#${prefix} fontWeight(string|number) = ${defaultFontWeight|default("'normal'")}
 
 <ExampleUIControlEnum default="normal" options="normal,bold,bolder,lighter" />
 

--- a/zh/option/series/bar.md
+++ b/zh/option/series/bar.md
@@ -420,7 +420,7 @@ option = {
 
 {{ target: partial-bar-item-style }}
 
-#${prefix} color(Color) = ${defaultColor|default('自适应')}
+#${prefix} color(Color) = ${defaultColor|default("'auto'")}
 
 <ExampleUIControlColor />
 


### PR DESCRIPTION
Some options are wrapped in quotation marks, others are not, single quotation marks should be used uniformly.