### PR TITLE
fix(axisPointer): typo of `margin` type

### DIFF
--- a/en/option/partial/axisPointer-common.md
+++ b/en/option/partial/axisPointer-common.md
@@ -229,7 +229,7 @@ formatter: function (params) {
 }
 ```
 
-##${prefix} margin(boolean) = 3
+##${prefix} margin(number) = 3
 
 Distance between label and axis.
 

--- a/zh/option/partial/axisPointer-common.md
+++ b/zh/option/partial/axisPointer-common.md
@@ -226,7 +226,7 @@ formatter: function (params) {
 }
 ```
 
-##${prefix} margin(boolean) = 3
+##${prefix} margin(number) = 3
 
 label 距离轴的距离。
 


### PR DESCRIPTION
- Only change `.md` docs.
- Seems like a long-existing tiny typo.