### PR TITLE
chore: remove event example for `dataZoom`

### DIFF
--- a/en/api/echarts-instance.md
+++ b/en/api/echarts-instance.md
@@ -343,7 +343,6 @@ If event is triggered externally by [dispatchAction](~echartsInstance.dispatchAc
     ```js
     chart.on('click', 'series', function () {...});
     chart.on('click', 'series.line', function () {...});
-    chart.on('click', 'dataZoom', function () {...});
     chart.on('click', 'xAxis.category', function () {...});
     ```
 

--- a/en/tutorial/event.md
+++ b/en/tutorial/event.md
@@ -107,7 +107,6 @@ If `string`, the formatter can be 'mainType' or 'mainType.subType'. For example:
 ```js
 chart.on('click', 'series', function () {...});
 chart.on('click', 'series.line', function () {...});
-chart.on('click', 'dataZoom', function () {...});
 chart.on('click', 'xAxis.category', function () {...});
 ```
 

--- a/zh/api/echarts-instance.md
+++ b/zh/api/echarts-instance.md
@@ -344,7 +344,6 @@ ECharts 中的事件有两种，一种是鼠标事件，在鼠标点击某个图
     ```js
     chart.on('click', 'series', function () {...});
     chart.on('click', 'series.line', function () {...});
-    chart.on('click', 'dataZoom', function () {...});
     chart.on('click', 'xAxis.category', function () {...});
     ```
 

--- a/zh/tutorial/event.md
+++ b/zh/tutorial/event.md
@@ -105,7 +105,6 @@ chart.on(eventName, query, handler);
 ```js
 chart.on('click', 'series', function () {...});
 chart.on('click', 'series.line', function () {...});
-chart.on('click', 'dataZoom', function () {...});
 chart.on('click', 'xAxis.category', function () {...});
 ```
 


### PR DESCRIPTION
Since add an event for `dataZoom` has limited interest,  so we should remove in doc so user wouldn't be confused.
- Close https://github.com/apache/echarts/issues/15775