### PR TITLE
fix: Removing colorAlpha for bug existence and low priority

### DIFF
--- a/en/option/series/treemap.md
+++ b/en/option/series/treemap.md
@@ -450,25 +450,6 @@ A color list for a level. Each node in the level will obtain a color from the co
 ) }}
 {{ /if }}
 
-#${prefix} colorAlpha(Array) = null
-
-{{ if: ${prefix} !== '#' }}
-It indicates the range of tranparent rate (color alpha) for nodes in a level
-{{ else }}
-It indicates the range of tranparent rate (color alpha) for nodes of the series
-{{ /if }}
-
-.
-The range of values is 0 ~ 1.
-
-For example, `colorAlpha` can be `[0.3, 1]`.
-
-{{ use: partial-treemap-visual-detial() }}
-
-{{ use: partial-treemap-prop-location-desc(
-    name = "colorAlpha"
-) }}
-
 #${prefix} colorSaturation(number) = null
 
 {{ if: ${prefix} !== '#' }}
@@ -677,12 +658,6 @@ About visual encoding, see details in [series-treemap.levels](~series-treemap.le
 The color of a node. It use global palette [option.color](~color) by default.
 
 {{ if: ${itemStyleType} === 'normal' }}
-#${prefix} colorAlpha(number) = null
-
-<ExampleUIControlNumber step="0.01" min="0" max="1" default="1" />
-
-The tranparent rate of a node, the range is between 0 ~ 1.
-
 #${prefix} colorSaturation(number) = null
 
 <ExampleUIControlNumber step="0.01" min="0" max="1" default="0.5" />

--- a/en/option/series/treemap.md
+++ b/en/option/series/treemap.md
@@ -450,6 +450,25 @@ A color list for a level. Each node in the level will obtain a color from the co
 ) }}
 {{ /if }}
 
+#${prefix} colorAlpha(Array) = null
+
+{{ if: ${prefix} !== '#' }}
+It indicates the range of tranparent rate (color alpha) for nodes in a level
+{{ else }}
+It indicates the range of tranparent rate (color alpha) for nodes of the series
+{{ /if }}
+
+.
+The range of values is 0 ~ 1.
+
+For example, `colorAlpha` can be `[0.3, 1]`.
+
+{{ use: partial-treemap-visual-detial() }}
+
+{{ use: partial-treemap-prop-location-desc(
+    name = "colorAlpha"
+) }}
+
 #${prefix} colorSaturation(number) = null
 
 {{ if: ${prefix} !== '#' }}
@@ -658,12 +677,6 @@ About visual encoding, see details in [series-treemap.levels](~series-treemap.le
 The color of a node. It use global palette [option.color](~color) by default.
 
 {{ if: ${itemStyleType} === 'normal' }}
-#${prefix} colorSaturation(number) = null
-
-<ExampleUIControlNumber step="0.01" min="0" max="1" default="0.5" />
-
-The color saturation of a node. The range is between 0 ~ 1.
-
 #${prefix} borderRadius(number|Array) = 0
 
 <ExampleUIControlVector min="0" dims="LT,RT, RB, LB" clean="true"  />

--- a/zh/option/series/treemap.md
+++ b/zh/option/series/treemap.md
@@ -596,24 +596,6 @@ treemap 默认把第一个维度（Array 第一项）映射到『面积』上。
 ) }}
 {{ /if }}
 
-#${prefix} colorAlpha(Array) = null
-
-{{ if: ${prefix} !== '#' }}
-表示同一层级的节点的颜色透明度选取范围。
-{{ else }}
-本系列默认的颜色透明度选取范围。
-{{ /if }}
-
-数值范围 0 ~ 1
-
-例如, `colorAlpha` 可以是 `[0.3, 1]`.
-
-{{ use: partial-treemap-visual-detial() }}
-
-{{ use: partial-treemap-prop-location-desc(
-    name = "colorAlpha"
-) }}
-
 #${prefix} colorSaturation(number) = null
 
 {{ if: ${prefix} !== '#' }}
@@ -818,12 +800,6 @@ treemap 默认把第一个维度（Array 第一项）映射到『面积』上。
 矩形的颜色。默认从全局调色盘 [option.color](~color) 获取颜色。
 
 {{ if: ${itemStyleType} === 'normal' }}
-#${prefix} colorAlpha(number) = null
-
-<ExampleUIControlNumber step="0.01" min="0" max="1" default="1" />
-
-矩形颜色的透明度。取值范围是 0 ~ 1 之间的浮点数。
-
 #${prefix} colorSaturation(number) = null
 
 <ExampleUIControlNumber step="0.01" min="0" max="1" default="0.5" />

--- a/zh/option/series/treemap.md
+++ b/zh/option/series/treemap.md
@@ -596,6 +596,24 @@ treemap 默认把第一个维度（Array 第一项）映射到『面积』上。
 ) }}
 {{ /if }}
 
+#${prefix} colorAlpha(Array) = null
+
+{{ if: ${prefix} !== '#' }}
+表示同一层级的节点的颜色透明度选取范围。
+{{ else }}
+本系列默认的颜色透明度选取范围。
+{{ /if }}
+
+数值范围 0 ~ 1
+
+例如, `colorAlpha` 可以是 `[0.3, 1]`.
+
+{{ use: partial-treemap-visual-detial() }}
+
+{{ use: partial-treemap-prop-location-desc(
+    name = "colorAlpha"
+) }}
+
 #${prefix} colorSaturation(number) = null
 
 {{ if: ${prefix} !== '#' }}
@@ -800,12 +818,6 @@ treemap 默认把第一个维度（Array 第一项）映射到『面积』上。
 矩形的颜色。默认从全局调色盘 [option.color](~color) 获取颜色。
 
 {{ if: ${itemStyleType} === 'normal' }}
-#${prefix} colorSaturation(number) = null
-
-<ExampleUIControlNumber step="0.01" min="0" max="1" default="0.5" />
-
-矩形颜色的饱和度。取值范围是 0 ~ 1 之间的浮点数。
-
 #${prefix} borderRadius(number|Array) = 0
 
 <ExampleUIControlVector min="0" dims="LT,RT, RB, LB" clean="true"  />


### PR DESCRIPTION
As is discussed in https://github.com/apache/echarts/pull/16760, `colorAlpha` should be removed because 
- A [bug](https://github.com/apache/echarts/issues/16749) is preventing this api to work properly and fixing it with [my PR](https://github.com/apache/echarts/pull/16760) will introduce **great workload** and **complexity**. 
- Developers can set opacity easily in `color` option with **rgba format**, so `colorAlpha` might not be needed anymore.

Removal of `colorAlpha` in source code will be implemented in following PRs at Echarts.