### PR TITLE
Fix params example for formatter code block

### DIFF
--- a/en/option/partial/formatter.md
+++ b/en/option/partial/formatter.md
@@ -34,4 +34,5 @@
     dimensionIndex: number,
     // Color of data
     color: string,
-
+}
+```


### PR DESCRIPTION
PR fixes the code block for the formatter `params` example so that it's now properly closed. Currently, because it's not properly closed, and so is messing up the HTML following it. An example of this is https://echarts.apache.org/en/option.html#tooltip.formatter.