### PR TITLE
Add square as allowed builtin icon

### DIFF
--- a/en/option/partial/icon.md
+++ b/en/option/partial/icon.md
@@ -32,7 +32,7 @@ A `dataURI` example:
 
 {{ target: partial-icon-buildin }}
 
-`'circle'`, `'rect'`, `'roundRect'`, `'triangle'`, `'diamond'`, `'pin'`, `'arrow'`, `'none'`
+`'circle'`, `'square'`, `'rect'`, `'roundRect'`, `'triangle'`, `'diamond'`, `'pin'`, `'arrow'`, `'none'`
 
 
 


### PR DESCRIPTION
PR adds `square` as an allowed builtin icon. I was looking at https://echarts.apache.org/en/option.html#legend.icon and it did not show `square`, though it does work, which was confusing to me.