### PR TITLE
doc: add doc for graphroam, georoam, and treeroam

### DIFF
--- a/en/api/events.md
+++ b/en/api/events.md
@@ -235,6 +235,59 @@ Event emitted after range is changed in visualMap.
 }
 ```
 
+## graphroam(Event)
+Event emitted after [series-graph](option.html#series-graph) is roamed.
+
+```ts
+{
+    type: 'graphroam',
+    seriesId: string,
+    zoom: number, // zoom ratio of roaming once
+    originX: number,
+    originY: number
+}
+```
+
+## georoam(Event)
+Event emitted after [geo](option.html#geo) is roamed.
+
+```ts
+{
+    type: 'georoam',
+    componentType: 'geo' | 'series',
+    seriesId: string,
+    zoom: number, // zoom ratio of roaming once
+    originX: number,
+    originY: number
+}
+```
+
+## treeroam(Event)
+Event emitted after [series-tree](option.html#series-tree) is roamed.
+
+`treeroam` events include two types. One is triggered by panning and the parameters are:
+
+```ts
+{
+    type: 'treeroam',
+    seriesId: string,
+    dx: number,
+    dy: number
+}
+```
+
+The other type is triggered by zooming and the parameters are:
+
+```ts
+{
+    type: 'treeroam',
+    seriesId: string,
+    zoom: number, // zoom ratio of roaming once
+    originX: number,
+    originY: number
+}
+```
+
 ## timelinechanged(Event)
 **ACTION:** [timelineChange](~action.timeline.timelineChange)
 Event emitted after time point in timeline is changed.
@@ -540,4 +593,3 @@ Use `dispatchAction` will trigger this event, but user clicking won't trigger it
     }
 }
 ```
-

--- a/zh/api/events.md
+++ b/zh/api/events.md
@@ -233,6 +233,59 @@ chart.on('mouseover', {seriesIndex: 1, name: 'xx'}, function (params) {
 }
 ```
 
+## graphroam(Event)
+关系图 [series-graph](option.html#series-graph) 的缩放和平移漫游事件。
+
+```ts
+{
+    type: 'graphroam',
+    seriesId: string,
+    zoom: number, // 单次缩放倍数
+    originX: number,
+    originY: number
+}
+```
+
+## georoam(Event)
+地理坐标系 [geo](option.html#geo) 的缩放和平移漫游事件。
+
+```ts
+{
+    type: 'georoam',
+    componentType: 'geo' | 'series',
+    seriesId: string,
+    zoom: number, // 单次缩放倍数
+    originX: number,
+    originY: number
+}
+```
+
+## treeroam(Event)
+树图 [series-tree](option.html#series-tree) 的缩放和平移漫游事件。
+
+`treeroam` 事件包括两种，其中一种是平移，事件参数为：
+
+```ts
+{
+    type: 'treeroam',
+    seriesId: string,
+    dx: number,
+    dy: number
+}
+```
+
+另一种是缩放，参数为：
+
+```ts
+{
+    type: 'treeroam',
+    seriesId: string,
+    zoom: number, // 单次缩放倍数
+    originX: number,
+    originY: number
+}
+```
+
 ## timelinechanged(Event)
 **ACTION:** [timelineChange](~action.timeline.timelineChange)
 时间轴中的时间点改变后的事件。
@@ -526,4 +579,3 @@ chart.on('finished', function () {
     }
 }
 ```
-


### PR DESCRIPTION
Many developers have asked how to listen to roaming events and I found this part of document is missing.