### PR TITLE
fix: fix default type of axisPointer in doc

### DIFF
--- a/zh/option/partial/axisPointer-common.md
+++ b/zh/option/partial/axisPointer-common.md
@@ -265,7 +265,7 @@ label 距离轴的距离。
     prefix = "#" + ${prefix},
     defaultColor = "#555",
     defaultWidth = 1,
-    defaultType = 'solid'
+    defaultType = 'dashed'
 ) }}
 
 #${prefix} shadowStyle(Object)


### PR DESCRIPTION
The default type of axisPointer is 'dashed' in [code](https://github.com/apache/echarts/blob/f2e8379c79341419a52cc6f43b669a8fb1d79dfb/src/component/axisPointer/AxisPointerModel.ts#L105)