### PR TITLE
fix typo in geo.md

### DIFF
--- a/en/option/component/geo.md
+++ b/en/option/component/geo.md
@@ -3,9 +3,9 @@
 
 # geo(Object)
 
-Geographic coorinate system component.
+Geographic coordinate system component.
 
-Geographic coorinate system component is used to draw maps, which also supports [scatter series](~series-scatter), and [line series](~series-lines).
+Geographic coordinate system component is used to draw maps, which also supports [scatter series](~series-scatter), and [line series](~series-lines).
 
 
 From `3.1.10`, geo component also supports mouse events, whose parameters are:


### PR DESCRIPTION
small typo under geo.md: 
from coorinate to coordinate
Source: https://en.wikipedia.org/wiki/Coordinate_(disambiguation)