### PR TITLE
chore(group-id): add version tip and fix inconsistent example link

### DIFF
--- a/en/option/partial/encode-dimensions.md
+++ b/en/option/partial/encode-dimensions.md
@@ -66,6 +66,7 @@ encode: {
     itemGroupId: 4,
     // Using dimension[5] as the child group ID for each data item. This option is introduced to
     // make multiple levels drilldown and aggregation animation come true. See childGroupId for more.
+    // Since v5.5.0
     itemChildGroupId: 5
 }
 

--- a/en/option/partial/group-id.md
+++ b/en/option/partial/group-id.md
@@ -23,6 +23,10 @@ If you are using the [dataset](~dataset) component to represent data, you are re
 
 #${prefix} childGroupId(string)
 
+{{ use: partial-version(
+    version = "5.5.0"
+) }}
+
 The group ID of the child data of a data item. This option is introduced to make multiple levels drilldown and aggregation animation possilbe.
 
 ~[700x300](${galleryViewPath}doc-example/bar-drilldown&edit=1&reset=1)

--- a/en/option/partial/group-id.md
+++ b/en/option/partial/group-id.md
@@ -29,7 +29,7 @@ If you are using the [dataset](~dataset) component to represent data, you are re
 
 The group ID of the child data of a data item. This option is introduced to make multiple levels drilldown and aggregation animation possilbe.
 
-~[700x300](${galleryViewPath}doc-example/bar-drilldown&edit=1&reset=1)
+~[700x300](${galleryViewPath}doc-example/bar-multi-drilldown&edit=1&reset=1)
 
 Before `childGroupId` is introduced, developers actually can use `groupId` to make drilldown and aggregation animation already, but with the limit on the times that a continious drilldown or aggregation can happen, which is only one time.
 

--- a/zh/option/partial/encode-dimensions.md
+++ b/zh/option/partial/encode-dimensions.md
@@ -58,6 +58,7 @@ encode: {
     // 指定数据项的组 ID (groupId)。当全局过渡动画功能开启时，setOption 前后拥有相同 groupId 的数据项会进行动画过渡。
     itemGroupId: 4,
     // 指定数据项对应的子数据组 ID (childGroupId)，用于实现多层下钻和聚合。详见 childGroupId。
+    // 从 v5.5.0 开始支持
     itemChildGroupId: 5
 }
 

--- a/zh/option/partial/group-id.md
+++ b/zh/option/partial/group-id.md
@@ -27,7 +27,7 @@
 
 该数据项对应的子数据组 ID，用于实现多层下钻和聚合。
 
-~[700x300](${galleryViewPath}doc-example/bar-drilldown&edit=1&reset=1)
+~[700x300](${galleryViewPath}doc-example/bar-multi-drilldown&edit=1&reset=1)
 
 通过`groupId`已经可以达到数据下钻和聚合的效果，但只支持一层的下钻和聚合。为了实现多层下钻和聚合，我们又引入了`childGroupId`。
 

--- a/zh/option/partial/group-id.md
+++ b/zh/option/partial/group-id.md
@@ -21,6 +21,10 @@
 
 #${prefix} childGroupId(string)
 
+{{ use: partial-version(
+    version = "5.5.0"
+) }}
+
 该数据项对应的子数据组 ID，用于实现多层下钻和聚合。
 
 ~[700x300](${galleryViewPath}doc-example/bar-drilldown&edit=1&reset=1)


### PR DESCRIPTION
reference: https://github.com/apache/echarts-doc/pull/295#discussion_r1038745524

Hi @plainheart, please review this PR. In this PR, I added a version tip for `childGroupId` and a version comment for `encode.itemChildGroupId`. Also, I fixed the inconsistent link to multi-drilldown example.