### PR TITLE
fix(toolbox): remove duplicated return in toolbox

### DIFF
--- a/en/option/component/toolbox.md
+++ b/en/option/component/toolbox.md
@@ -515,7 +515,7 @@ option = {
         tooltip: { // same as option.tooltip
             show: true,
             formatter: function (param) {
-                return return '<div>' + param.title + '</div>'; // user-defined DOM structure
+                return '<div>' + param.title + '</div>'; // user-defined DOM structure
             },
             backgroundColor: '#222',
             textStyle: {

--- a/zh/option/component/toolbox.md
+++ b/zh/option/component/toolbox.md
@@ -588,7 +588,7 @@ option = {
         tooltip: { // 和 option.tooltip 的配置项相同
             show: true,
             formatter: function (param) {
-                return return '<div>' + param.title + '</div>'; // 自定义的 DOM 结构
+                return '<div>' + param.title + '</div>'; // 自定义的 DOM 结构
             },
             backgroundColor: '#222',
             textStyle: {


### PR DESCRIPTION
The toolbox tooltip example contained invalid JS with a duplicated return statement.