### PR TITLE
fix(barGrid):Modify the default value of the barGap attribute and the default value of the barCategoryGap attribute 

### DIFF
--- a/en/option/partial/barGrid.md
+++ b/en/option/partial/barGrid.md
@@ -49,6 +49,8 @@ The minimum angle of bar. It could be used to avoid the following situation: the
 
 ## barGap(string) = ${barGapDefault|default('20%')}
 
+<ExampleUIControlPercent default="${barGapDefault|default('20%')}"/>
+
 The gap between bars between different series, is a percent value like `'20%'`, which means `20%` of the bar width.
 
 Set barGap as `'-100%'` can overlap bars that belong to different series, which is useful when making a series of bar be background.

--- a/en/option/partial/barGrid.md
+++ b/en/option/partial/barGrid.md
@@ -47,9 +47,9 @@ The minimum angle of bar. It could be used to avoid the following situation: the
 
 <ExampleUIControlNumber min="0" />
 
-## barGap(string) = ${barGapDefault|default('30%')}
+## barGap(string) = ${barGapDefault|default('20%')}
 
-The gap between bars between different series, is a percent value like `'30%'`, which means `30%` of the bar width.
+The gap between bars between different series, is a percent value like `'20%'`, which means `20%` of the bar width.
 
 Set barGap as `'-100%'` can overlap bars that belong to different series, which is useful when making a series of bar be background.
 
@@ -60,9 +60,9 @@ Set barGap as `'-100%'` can overlap bars that belong to different series, which 
 For example:
 ~[600x400](${galleryViewPath}doc-example/barGrid-barGap&reset=1&edit=1)
 
-## barCategoryGap(string) = '20%'
+## barCategoryGap(number|string)
 
-The bar gap of a single series, defaults to be `20%` of the category gap, can be set as a fixed value.
+The bar gap of a single series, by default, a suitable spacing is calculated based on the number of series in the bar chart. When there are more series, the spacing will be appropriately reduced, can be set as a fixed value.
 
 {{ use: partial-barGrid-share-desc(
     seriesType = ${seriesType}

--- a/zh/option/partial/barGrid.md
+++ b/zh/option/partial/barGrid.md
@@ -51,7 +51,7 @@
 
 ## barGap(string) = ${barGapDefault|default('20%')}
 
-<ExampleUIControlPercent default="20%"/>
+<ExampleUIControlPercent default="${barGapDefault|default('20%')}"/>
 
 不同系列的柱间距离，为百分比（如 `'20%'`，表示柱子宽度的 `20%`）。
 

--- a/zh/option/partial/barGrid.md
+++ b/zh/option/partial/barGrid.md
@@ -49,11 +49,11 @@
 
 <ExampleUIControlNumber min="0" />
 
-## barGap(string) = ${barGapDefault|default('30%')}
+## barGap(string) = ${barGapDefault|default('20%')}
 
-<ExampleUIControlPercent default="30%"/>
+<ExampleUIControlPercent default="20%"/>
 
-不同系列的柱间距离，为百分比（如 `'30%'`，表示柱子宽度的 `30%`）。
+不同系列的柱间距离，为百分比（如 `'20%'`，表示柱子宽度的 `20%`）。
 
 如果想要两个系列的柱子重叠，可以设置 barGap 为 `'-100%'`。这在用柱子做背景的时候有用。
 
@@ -64,11 +64,11 @@
 例子：
 ~[600x400](${galleryViewPath}doc-example/barGrid-barGap&reset=1&edit=1)
 
-## barCategoryGap(string) = '20%'
+## barCategoryGap(number|string)
 
-<ExampleUIControlPercent default="20%"/>
+<ExampleUIControlPercent />
 
-同一系列的柱间距离，默认为类目间距的20%，可设固定值
+同一系列的柱间距离，默认情况下根据柱状图的系列数量计算得到合适的间距，系列较多时间距会适当调小，可设固定值
 
 {{ use: partial-barGrid-share-desc(
     seriesType = ${seriesType}


### PR DESCRIPTION
According to this problem, it was found that there is a discrepancy between the document and the actual situation.
[Bug] Default value of `barCategoryGap` and `barGap` not as described in the document apache/echarts#20148

There is a discrepancy between the documentation and the code. When setting `barGap`, the default value should be 20% instead of 30%. The specific change results are as shown in the figure.

<img width="755" alt="image" src="https://github.com/user-attachments/assets/823adc69-cb24-4ebe-a501-f43f130af026">
<img width="762" alt="image" src="https://github.com/user-attachments/assets/c1c277f2-7e45-41bf-b630-9fd437783985">

The default value of `barCategoryGap` is a value calculated based on the number of bar series. Relevant instructions should be added to the document. As shown in the figure

<img width="831" alt="image" src="https://github.com/user-attachments/assets/ee1a7acb-874b-46b0-b309-f97160783715">
<img width="943" alt="image" src="https://github.com/user-attachments/assets/9cbf8a52-bd0f-4b19-b762-ea82789b3385">



