### PR TITLE
Grammar and spelling improvements for feature page

### DIFF
--- a/en/tutorial/echarts-feature.md
+++ b/en/tutorial/echarts-feature.md
@@ -1,19 +1,19 @@
 {{ target: echarts-feature }}
-# Introduction of ECharts features
+# Introduction to ECharts features
 
-Apache ECharts<sup>TM</sup>, a pure Javascript chart library, can run smoothly on PC and mobile devices, being compatible with most of current Web browsers (IE8/9/10/11, Chrome, Firefox, Safari and so on), it relies on a lightweight Canvas library [ZRender](https://github.com/ecomfe/zrender), and provides intuitive, vivid, interactive, and highly customizable data visualization charts.
+Apache ECharts<sup>TM</sup> is an open-source, pure Javascript chart library that can run smoothly on PC and mobile devices. Compatible with most current web browsers (IE8/9/10/11, Chrome, Firefox, Safari and so on), it relies on a lightweight Canvas library ([ZRender](https://github.com/ecomfe/zrender)) and provides intuitive, interactive, and highly customizable data visualizations.
 
 More over, ECharts 3 adds richer interactive functions and more visualization effects, and optimizes more deeply on mobile end.
 
-## Rich chart types
+## Rich Chart Types
 
-ECharts provides regular [line charts](option.html#series-line), [bar charts](option.html#series-line), [scatter charts](option.html#series-scatter), [pie charts](option.html#series-pie), [K line charts](option.html#series-candlestick), [box charts](option.html#series-boxplot) used for statistics, [maps](option.html#series-map) used for geo-data visualization, [heatmaps](option.html#series-heatmap), [line charts](option.html#series-lines), [Graph charts](option.html#series-graph) used for data relationship visualization, [treemap](option.html#series-treemap), [parallel charts](option.html#series-parallel) for multi-dimensional data visualization, [funnel maps](option.html#series-funnel) for BI, [gauge charts](option.html#series-gauge), and supports connection and interaction between graphics.
+ECharts provides [line charts](option.html#series-line), [bar charts](option.html#series-line), [scatter charts](option.html#series-scatter), [pie charts](option.html#series-pie), [K line charts](option.html#series-candlestick) and [box charts](option.html#series-boxplot), as well as [maps](option.html#series-map) used for geodata visualization, [heatmaps](option.html#series-heatmap), [treemaps](option.html#series-treemap), [parallel charts](option.html#series-parallel) for multi-dimensional data visualization, [funnel maps](option.html#series-funnel) for BI, [gauge charts](option.html#series-gauge). Additionally, it supports connecting and animating between different graphic types.
 
-You can download a whole package of all chart components, or you may select the ones you need with online construction builder, if the full package is too large for you.
+You can either download the entire package of chart components or instead select the ones you need with the [online package builder](builder.html) to reduce file sizes.
 
-## Support of multiple coordinate
+## Support for Multiple Coordinate Types
 
-ECharts started to separate the concept of "coordinate" from 3.0, supporting rectangular coordinate (containing catesian, as well as grid), polar coordinate (polar), geographic coordinate (geo). Charts can cross coordinate. For example, line chart, bar chart and scatter chart can be placed in the same rectangular coordinate or polar  coordinate or even geographic coordinate.
+ECharts started to separate the concept of "coordinate" from 3.0, supporting rectangular coordinates (containing Cartesian, as well as grid), polar coordinates and geographic coordinates. Charts can cross coordinate. For example, line charts, bar charts and scatter charts can be placed in the same rectangular coordinate or polar coordinate sustem.
 
 Below is an example that a line chart is in polar coordinate:
 
@@ -22,34 +22,32 @@ Below is an example that a line chart is in polar coordinate:
 
 ## Mobile Optimization
 
-Precious bandwidth limits Mobile devices with small chart library size. Reconstructing ECharts and ZRender code minimizes it to the smallest size. ECharts has a large number of components and the number is still increasing. So we provide a finer-grained packaging method on demand. The minimum size has been shrunk to 40% of ECharts 2.
+Bandwidth is precious on mobile devices and so ECharts has been optimized to use a small file size. ECharts many components (with the total ever increasing) and so we provide mobile-optimised small packages.
 
-Interaction on mobile has also been optimized, like zooming and translating in coordinates with fingers on small screen of mobile. Zooming and translating are also available with mouse scrolling on PC. See the example below:
+Interaction on mobile is also optimized: zooming and panning is natively supported on both mobile and desktop. See the example below:
 
 
 ~[60%x400](${galleryViewPath}area-simple&reset=1&edit=1)
 
-## Interactive Data Exploration in Depth
+## Interactive Data Exploration
 
-Interaction is an important way to dig information from data. Overview by default, zoom and filter to check details based on needs are basic requirements of data visualization interaction.
+Interactivity is key to analyzing and understanding data. Whilst ECharts provides an overview by default, zooming and data filtering can be modified to meet the needs of the data visualization.
 
-ECharts is constantly moving forward on the road of *interaction*, we provide components like [legend](option.html#legend), [visualMap](option.html#visualMap), [dataZoom](option.html#dataZoom), [tooltip](option.html#tooltip), as well as data roaming. Operations like selecting enables you to filter data, zoom viewport, and display details.
-
-ECharts 3 comprehensively strenghtens these components. Such as supporting filtering and zooming on all kinds of data axis and dimensions, and enables these components in more types of charts. See the example below:
+ECharts is constantly expanding on this interactivity; we provide components like [legend](option.html#legend), [visualMap](option.html#visualMap), [dataZoom](option.html#dataZoom) and [tooltip](option.html#tooltip). Selections enables you to filter data, zoom the viewport, and display more detail.
 
 ~[60%x400](${galleryViewPath}mix-zoom-on-value&reset=1&edit=1)
 
-## Data in Large Scale
+## Large-Scale Datasets
 
-With the help of Canvas, ECharts can easily display tens of thousands, or even hundreds of thousands data in scatter chart.
+With the help of the Canvas element, ECharts can easily display tens of thousands, or even hundreds of thousands data points in a scatter chart.
 
-The following Weibo signing chart displays 100k+ signing data.
+The following charge contains over 100,000 data points:
 
 ~[60%x400](${galleryViewPath}scatter-weibo&reset=1&edit=1)
 
-## Multi-Dimensional Data Support and Rich Presentation of Visual Coding
+## Multi-Dimensional Data Support and Rich Presentation
 
-ECharts 3 enhances the support of multi-dimensional data. Besides adding common multi-dimensional data visualization tools like parallel coordinates, it supports mult-dimensional for charts like traditional scatter charts. And with the help of [visualMap](option.html#visualMap), you can map data of different dimensions to color, size, opacity, lightness and other different visual tunnels, which provides an even richer visual presentation.
+ECharts 3 adds support for multi-dimensional data. Besides common multi-dimensional data visualization tools like parallel coordinates, it supports multiple dimensions for other charts like traditional scatter plots. With the help of [visualMap](option.html#visualMap), you can map data of different dimensions to color, size, opacity, lightness and other different visual attributes, helping create rich data visualizations.
 
 ~[60%x500](${galleryViewPath}scatter-aqi-color&reset=1&edit=1)
 
@@ -61,6 +59,6 @@ ECharts is data-driven, in that the change of data changes the presentation of c
 
 ## Splendid Special Effects
 
-ECharts provides eye-catching special effects for visualization of line data, point data and geo-data, and so on.
+ECharts provides eye-catching special effects for visualization of line data, point data and geo-data.
 
 ~[60%x400](${galleryViewPath}lines-bmap-effect&reset=1&edit=1)

--- a/en/tutorial/echarts-feature.md
+++ b/en/tutorial/echarts-feature.md
@@ -9,7 +9,7 @@ More over, ECharts 3 adds richer interactive functions and more visualization ef
 
 ECharts provides [line charts](option.html#series-line), [bar charts](option.html#series-line), [scatter charts](option.html#series-scatter), [pie charts](option.html#series-pie), [K line charts](option.html#series-candlestick) and [box charts](option.html#series-boxplot), as well as [maps](option.html#series-map) used for geodata visualization, [heatmaps](option.html#series-heatmap), [treemaps](option.html#series-treemap), [parallel charts](option.html#series-parallel) for multi-dimensional data visualization, [funnel maps](option.html#series-funnel) for BI, [gauge charts](option.html#series-gauge). Additionally, it supports connecting and animating between different graphic types.
 
-You can either download the entire package of chart components or instead select the ones you need with the [online package builder](builder.html) to reduce file sizes.
+You can either download the entire package of chart components or instead select the ones you need with the [online package builder](builder.html) to reduce the library's footprint.
 
 ## Support for Multiple Coordinate Types
 
@@ -22,7 +22,7 @@ Below is an example that a line chart is in polar coordinate:
 
 ## Mobile Optimization
 
-Bandwidth is precious on mobile devices and so ECharts has been optimized to use a small file size. ECharts many components (with the total ever increasing) and so we provide mobile-optimised small packages.
+Bandwidth is precious on mobile devices and so ECharts has been optimized to use a small file size. ECharts has many components (with more being added) and so we provide mobile-optimised, smaller packages.
 
 Interaction on mobile is also optimized: zooming and panning is natively supported on both mobile and desktop. See the example below:
 


### PR DESCRIPTION
There seems to be a discrepancy between the `echarts-feature.md` file on this repo and [the one online](https://echarts.apache.org/en/feature.html), but I have edited here regardless. Currently, it reads very awkwardly and so I have
- Fixed grammar and spelling
- Restructured some sections
- Removed redundant sentences
- Make the title case be consistent
Hopefully this is helpful.