### PR TITLE
docs(radar): replace deprecated nameGap with axisNameGap

### DIFF
--- a/en/option/component/radar.md
+++ b/en/option/component/radar.md
@@ -52,7 +52,7 @@ formatter: function (value, indicator) {
     noVerticalAlign = true
 ) }}
 
-## nameGap(number) = 15
+## axisNameGap(number) = 15
 
 <ExampleUIControlNumber default="15" step="1" />
 

--- a/zh/option/component/radar.md
+++ b/zh/option/component/radar.md
@@ -88,7 +88,7 @@ formatter: function (value, indicator) {
     noVerticalAlign = true
 ) }}
 
-## nameGap(number) = 15
+## axisNameGap(number) = 15
 
 <ExampleUIControlNumber default="15" step="1" />
 


### PR DESCRIPTION
### Summary

This PR updates the radar chart documentation to reflect that the `nameGap` option has been deprecated since ECharts v5 and should be replaced with `axisNameGap`.

### Changes Made

- Replace deprecated `nameGap` with `axisNameGap`
- Applied changes to both Chinese and English documentation

### Motivation

As of ECharts v5, `nameGap` has been officially deprecated but still appears in the documentation, which may confuse developers. This change aligns the documentation with the current API usage.

### Related Issue

Fixes the discrepancy in the radar option documentation and improves developer guidance.

---

Let me know if any adjustments are needed. Happy to help further clarify or tweak the wording.