### PR TITLE
doc: improve stackOrder documentation with usage notes

### DIFF
--- a/en/option/series/bar.md
+++ b/en/option/series/bar.md
@@ -167,6 +167,8 @@ Stack order. Optional values:
 + `'seriesAsc'` (default, stack in series order)
 + `'seriesDesc'` (reverse stack order)
 
+**Note:** `stackOrder` should be defined for all series with the same `stack` name. If `stackOrder` is defined for only some of the series, the stack order may change unexpectedly when certain series are hidden (e.g., through legend toggle).
+
 Not supported in polar coordinate system.
 
 ## sampling(string)

--- a/en/option/series/line.md
+++ b/en/option/series/line.md
@@ -91,6 +91,8 @@ Stack order. Optional values:
 + `'seriesAsc'` (default, stack in series order)
 + `'seriesDesc'` (reverse stack order)
 
+**Note:** `stackOrder` should be defined for all series with the same `stack` name. If `stackOrder` is defined for only some of the series, the stack order may change unexpectedly when certain series are hidden (e.g., through legend toggle).
+
 Not supported in polar coordinate system.
 
 {{ use: partial-cursor() }}

--- a/zh/option/series/bar.md
+++ b/zh/option/series/bar.md
@@ -243,6 +243,8 @@ option = {
 + `'seriesAsc'`（默认，系列顺序堆叠）
 + `'seriesDesc'`（反向堆叠）
 
+**注意：** `stackOrder` 应该为所有具有相同 `stack` 名称的系列定义。如果只为部分系列定义 `stackOrder`，当某些系列被隐藏（如通过图例切换）时，可能会导致堆叠顺序发生意外变化。
+
 当前不支持极坐标系。
 
 ## sampling(string)

--- a/zh/option/series/line.md
+++ b/zh/option/series/line.md
@@ -118,6 +118,8 @@ const option = {
 + `'seriesAsc'`（默认，系列顺序堆叠）
 + `'seriesDesc'`（反向堆叠）
 
+**注意：** `stackOrder` 应该为所有具有相同 `stack` 名称的系列定义。如果只为部分系列定义 `stackOrder`，当某些系列被隐藏（如通过图例切换）时，可能会导致堆叠顺序发生意外变化。
+
 当前不支持极坐标系。
 
 {{ use: partial-cursor() }}


### PR DESCRIPTION
- Add important note that stackOrder should be defined for all series with the same stack name
- Explain potential issues when stackOrder is only defined for some series
- Address feedback from PR #448 comments