### PR TITLE
fix(jitter): add doc for jitterOverlap and jitterMargin

### DIFF
--- a/en/option/component/axis-common.md
+++ b/en/option/component/axis-common.md
@@ -31,7 +31,21 @@ Parameters of the event include:
 
 To prevent data points from overlapping in scatter plots, a small amount of random noise is added to the positions of the data points. This helps to visualize the distribution of the data more clearly. It is only applicable to scatter plots and is effective only in single-axis or category axes in Cartesian coordinate systems. The unit is in pixels.
 
-~[600x400](${galleryViewPath}scatter-jitter&edit=1&reset=1)
+~[800x500](${galleryViewPath}scatter-jitter&edit=1&reset=1)
+
+#${prefix} jitterOverlap(boolean) = true
+
+{{ use: partial-version(version = "6.0.0") }}
+
+Whether allow overlaping with [jitter](~${componentType}.jitter). If `false`, it will try to avoid overlap. But in extreme cases, some scatters may also overlap if there is no way to avoid. The following is the effect of seeting it to be `false`:
+
+~[800x500](${galleryViewPath}doc-example/scatter-jitter-avoidOverlap&edit=1&reset=1)
+
+#${prefix} jitterMargin(number) = 2
+
+{{ use: partial-version(version = "6.0.0") }}
+
+When setting [jitter](~${componentType}.jitter) and [jitterOverlap](~${componentType}.jitterOverlap) is `false`, the minimum distance between two scatters.
 
 #${prefix} axisLine(Object)
 

--- a/zh/option/component/axis-common.md
+++ b/zh/option/component/axis-common.md
@@ -29,7 +29,21 @@
 
 用于在散点图中防止数据点重叠，通过在数据点的位置上添加少量随机噪音来实现，可以帮助更清晰地可视化数据的分布。仅适用于散点图，且仅在单轴或笛卡尔坐标系下的类目轴中有效。单位是像素。
 
-~[600x400](${galleryViewPath}scatter-jitter&edit=1&reset=1)
+~[800x500](${galleryViewPath}scatter-jitter&edit=1&reset=1)
+
+#${prefix} jitterOverlap(boolean) = true
+
+{{ use: partial-version(version = "6.0.0") }}
+
+是否允许 [jitter](~${componentType}.jitter) 重叠。如果设为 `false`，将尽可能避免重叠，极端情况下如果重叠是无法避免的，则也可能出现重叠。以下是设为 `false` 的效果：
+
+~[800x500](${galleryViewPath}doc-example/scatter-jitter-avoidOverlap&edit=1&reset=1)
+
+#${prefix} jitterMargin(number) = 2
+
+{{ use: partial-version(version = "6.0.0") }}
+
+在设置了 [jitter](~${componentType}.jitter) 且 [jitterOverlap](~${componentType}.jitterOverlap) 为 `false` 的情况下，两个数据点之间的最小距离。
 
 #${prefix} axisLine(Object)
 


### PR DESCRIPTION
`jitterOverlap` and `jitterMargin` were missing from the doc.