### PR TITLE
feat(radar): add clockwise layout doc

### DIFF
--- a/en/option/component/radar.md
+++ b/en/option/component/radar.md
@@ -29,6 +29,14 @@ Here is a custom example of radar component.
     none = true
 ) }}
 
+## clockwise(boolean) = false
+
+{{ use: partial-version(version = "6.0.1") }}
+
+<ExampleUIControlBoolean default="false" />
+
+Whether to clockwise layout indicator axis.
+
 ## startAngle(number) = 90
 
 The start angle of coordinate, which is the angle of the first indicator axis.

--- a/zh/option/component/radar.md
+++ b/zh/option/component/radar.md
@@ -65,6 +65,14 @@ const option = {
     none = true
 ) }}
 
+## clockwise(boolean) = false
+
+{{ use: partial-version(version = "6.0.1") }}
+
+<ExampleUIControlBoolean default="false" />
+
+是否以顺时针排布指示器轴。
+
 ## startAngle(number) = 90
 
 坐标系起始角度，也就是第一个指示器轴的角度。


### PR DESCRIPTION
This pull request adds documentation for the new `clockwise` property to the radar component in both the English and Chinese documentation. The `clockwise` property determines whether the indicator axes are laid out in a clockwise direction.

Documentation updates:

* Added a section describing the `clockwise(boolean) = false` property to `en/option/component/radar.md`, including its default value, version, a UI control example, and a description.
* Added a corresponding section for the `clockwise(boolean) = false` property to `zh/option/component/radar.md` with a translated description and matching UI control example.