### PR TITLE
Mention 'center' top placement option

### DIFF
--- a/en/option-gl/partial/viewport.md
+++ b/en/option-gl/partial/viewport.md
@@ -14,7 +14,7 @@ Distance between ${componentName} component and the top side of the container.
 
 `top` value can be instant pixel value like `20`; it can also be a percentage value relative to container width like `'20%'`; and it can also be `'top'`, `'middle'`, or `'bottom'`.
 
-If the `top` value is set to be `'top'`, `'middle'`, or `'bottom'`, then the component will be aligned automatically based on position.
+If the `top` value is set to be `'top'`, `'middle'`, `'center'`, or `'bottom'`, then the component will be aligned automatically based on position.
 
 #${prefix|default("#")} right(string|number) = ${defaultRight|default('auto')}
 


### PR DESCRIPTION
According to testing and https://github.com/apache/echarts/blob/d0d53db621f92a6085213b53668853e63d7c7d85/src/util/number.ts#L116 it is possible to use not only 'middle' but 'center' as placement option too.