### PR TITLE
doc(axis): fix typo in axis.max description

### DIFF
--- a/en/option-gl/component/axis3D-axis-common.md
+++ b/en/option-gl/component/axis3D-axis-common.md
@@ -52,7 +52,7 @@ In the category axis, it can also be set as the ordinal number. For example, if 
 
 The maximum value of the axis.
 
-It can be set to a special value `'dataMax'` so that the minimum value on this axis is set to be the maximum label.
+It can be set to a special value `'dataMax'` so that the maximum value on this axis is set to be the maximum label.
 
 It will be automatically computed to make sure the axis tick is equally distributed when not set.
 

--- a/en/option/component/axis-common.md
+++ b/en/option/component/axis-common.md
@@ -917,7 +917,7 @@ min: function (value) {
 
 The maximum value of axis.
 
-It can be set to a special value `'dataMax'` so that the minimum value on this axis is set to be the maximum label.
+It can be set to a special value `'dataMax'` so that the maximum value on this axis is set to be the maximum label.
 
 It will be automatically computed to make sure axis tick is equally distributed when not set.
 


### PR DESCRIPTION
doc(axis): fix typo in axis.max description

"dataMax" does set the maximum value, not the minimum value