### PR TITLE
feat(sankey): add sortNodes to Sankey documentation

### DIFF
--- a/en/option/series/sankey.md
+++ b/en/option/series/sankey.md
@@ -77,7 +77,17 @@ Note when [orient](~series-sankey.orient) is `vertical`, `nodeAlign` controls ve
 
 <ExampleUIControlNumber default="32" min="0" max="100" step="1" />
 
-The iterations of layout, which is used to iteratively optimize the position of the nodes and edges in the Sankey diagram to reduce the overlapping between nodes and edges. The default value is `32`. If you want the order of the nodes in the chart to be the same with the order in the original [data](~series-sankey.data), you can set the value to be `0`.
+The iterations of layout, which is used to iteratively optimize the position of the nodes and edges in the Sankey diagram to reduce the overlapping between nodes and edges. The default value is `32`.
+
+If you want to preserve the original order of nodes within each depth level while still using layout optimization, consider using [sortNodes](~series-sankey.sortNodes) instead of setting this value to `0`.
+
+## sortNodes(boolean) = true
+
+<ExampleUIControlBoolean default="true" />
+
+Whether to sort nodes within each depth level during layout collision resolution.
+
+By default, nodes are automatically sorted based on their computed position to reduce edge crossings and improve layout readability. If set to `false`, the original order of nodes defined in [data](~series-sankey.data) is preserved within each depth level, while the layout algorithm still performs the other layout optimization.
 
 ## orient(string) = 'horizontal'
 

--- a/en/option/series/sankey.md
+++ b/en/option/series/sankey.md
@@ -79,15 +79,19 @@ Note when [orient](~series-sankey.orient) is `vertical`, `nodeAlign` controls ve
 
 The iterations of layout, which is used to iteratively optimize the position of the nodes and edges in the Sankey diagram to reduce the overlapping between nodes and edges. The default value is `32`.
 
-If you want to preserve the original order of nodes within each depth level while still using layout optimization, consider using [sortNodes](~series-sankey.sortNodes) instead of setting this value to `0`.
+If you want to preserve the original order of nodes within each depth level while still using layout optimization, consider using [sort](~series-sankey.sort) and set it to `null` instead of setting this value to `0`.
 
-## sortNodes(boolean) = true
+## sort(string) = 'desc'
 
-<ExampleUIControlBoolean default="true" />
+<ExampleUIControlEnum options="desc,null" />
 
 Whether to sort nodes within each depth level during layout collision resolution.
 
-By default, nodes are automatically sorted based on their computed position to reduce edge crossings and improve layout readability. If set to `false`, the original order of nodes defined in [data](~series-sankey.data) is preserved within each depth level, while the layout algorithm still performs the other layout optimization.
+By default, this option is `'desc'`, which preserves the previous behavior. When `sort` is `undefined`, the default option still makes it behave as `'desc'`.
+
+Set `sort` to `null` to disable per-depth node sorting and preserve the original order of nodes defined in [data](~series-sankey.data) within each depth level, while the layout algorithm still performs the other layout optimization.
+
+Currently, Sankey only supports `'desc'` and `null`. `asc` order and custom sort callbacks are not supported.
 
 ## orient(string) = 'horizontal'
 

--- a/en/option/series/sankey.md
+++ b/en/option/series/sankey.md
@@ -87,7 +87,7 @@ If you want to preserve the original order of nodes within each depth level whil
 
 Whether to sort nodes within each depth level during layout collision resolution.
 
-By default, this option is `'desc'`, which preserves the previous behavior. When `sort` is `undefined`, the default option still makes it behave as `'desc'`.
+By default, this option is `'desc'`. When `sort` is `undefined`, the default option still makes it behave as `'desc'`.
 
 Set `sort` to `null` to disable per-depth node sorting and preserve the original order of nodes defined in [data](~series-sankey.data) within each depth level, while the layout algorithm still performs the other layout optimization.
 

--- a/zh/option/series/sankey.md
+++ b/zh/option/series/sankey.md
@@ -88,7 +88,7 @@ const option = {"tooltip":{"trigger":"item","triggerOn":"mousemove"},"series":[{
 
 是否在布局碰撞解决过程中对每一层内的节点进行排序。
 
-默认值是 `'desc'`，这会保持之前的行为。当 `sort` 为 `undefined` 时，也会因默认值而按 `'desc'` 处理。
+默认值是 `'desc'`。当 `sort` 为 `undefined` 时，也会因默认值而按 `'desc'` 处理。
 
 将 `sort` 设为 `null` 可以关闭每一层内的节点排序，并保留 [data](~series-sankey.data) 中定义的原始顺序，同时布局算法仍会执行其他优化。
 

--- a/zh/option/series/sankey.md
+++ b/zh/option/series/sankey.md
@@ -80,7 +80,19 @@ const option = {"tooltip":{"trigger":"item","triggerOn":"mousemove"},"series":[{
 
 <ExampleUIControlNumber default="32" min="0" max="100" step="1" />
 
-布局的迭代次数，目的是不断迭代优化图中节点和边的位置，以减少节点和边之间的相互遮盖，默认值是 `32`。如果希望图中节点的顺序是按照原始 [data](~series-sankey.data) 中的顺序排列的，可设该值为 `0`。
+布局的迭代次数，目的是不断迭代优化图中节点和边的位置，以减少节点和边之间的相互遮盖，默认值是 `32`。如果希望在保持布局优化的同时，保留每一层节点在 [data](~series-sankey.data) 中的原始顺序，建议使用 [sort](~series-sankey.sort) 并将其设为 `null`，而不是将此值设为 `0`。
+
+## sort(string) = 'desc'
+
+<ExampleUIControlEnum options="desc,null" />
+
+是否在布局碰撞解决过程中对每一层内的节点进行排序。
+
+默认值是 `'desc'`，这会保持之前的行为。当 `sort` 为 `undefined` 时，也会因默认值而按 `'desc'` 处理。
+
+将 `sort` 设为 `null` 可以关闭每一层内的节点排序，并保留 [data](~series-sankey.data) 中定义的原始顺序，同时布局算法仍会执行其他优化。
+
+当前 Sankey 仅支持 `'desc'` 和 `null`。未添加 `asc` 排序或自定义回调排序的支持。
 
 ## orient(string) = 'horizontal'
 


### PR DESCRIPTION
Documentation changes required for https://github.com/apache/echarts/pull/21562

Add documentation for `sortNodes` in Sankey chart.