### PR TITLE
Replace tutorial section with handbook link in llms.txt

### DIFF
--- a/build/build-llms.js
+++ b/build/build-llms.js
@@ -26,9 +26,13 @@ const OUTPUT_DIR_NAME = 'llms-documents';
 const MAX_HEADING_DEPTH = 6;
 
 const SECTION_LABELS = {
-    en: {'option-parts': 'Option', 'option-gl-parts': 'Option GL', 'api-parts': 'API', 'tutorial-parts': 'Tutorial'},
-    zh: {'option-parts': '配置项 (Option)', 'option-gl-parts': 'GL配置项 (Option GL)', 'api-parts': 'API', 'tutorial-parts': '教程 (Tutorial)'}
+    en: {'option-parts': 'Option', 'option-gl-parts': 'Option GL', 'api-parts': 'API'},
+    zh: {'option-parts': '配置项 (Option)', 'option-gl-parts': 'GL配置项 (Option GL)', 'api-parts': 'API'}
 };
+
+// Tutorial parts are excluded because they have been replaced by the echarts-handbook.
+// A link to the handbook is included in the llms.txt instead.
+const EXCLUDED_PARTS = new Set(['tutorial-parts']);
 
 const LLMS_TXT_HEADER = [
     '# Apache ECharts Documentation',
@@ -66,7 +70,7 @@ function htmlToMd(html) {
  *   e.g. { "option.title.show": {type: "boolean", default: "true"} }
  */
 function buildTypeMap(schemaJsonPath, docName) {
-    if (docName === 'tutorial' || !fs.existsSync(schemaJsonPath)) return {};
+    if (!fs.existsSync(schemaJsonPath)) return {};
     const schema = JSON.parse(fs.readFileSync(schemaJsonPath, 'utf-8'));
     const typeMap = {};
     traverse(schema, docName, (schemaPath, node) => {
@@ -304,7 +308,7 @@ function generateDocsForLang(lang) {
         cwd: docsDir,
         absolute: true,
         onlyDirectories: true
-    });
+    }).filter(dir => !EXCLUDED_PARTS.has(path.basename(dir)));
     const jsonFilesByDir = collectPartJsonFiles(partsDirs);
     const partKeysByDoc = buildPartKeysByDoc(partsDirs, jsonFilesByDir);
 
@@ -348,7 +352,13 @@ function writeLlmsTxt(lang, files) {
             ''
         ]);
 
-    const content = [LLMS_TXT_HEADER, ...sections].join('\n').trimEnd() + '\n';
+    const handbookSection = [
+        '## Handbook', '',
+        `- [ECharts Handbook](https://echarts.apache.org/handbook/${lang}/get-started)`,
+        ''
+    ];
+
+    const content = [LLMS_TXT_HEADER, ...sections, ...handbookSection].join('\n').trimEnd() + '\n';
     fs.writeFileSync(path.join(langDir, 'llms.txt'), content, 'utf-8');
     console.log(`Generated ${lang}/llms.txt`);
 }


### PR DESCRIPTION
## Summary

- Remove tutorial section from llms.txt and replace with echarts-handbook link
- Add Handbook section linking to the handbook entry page

<details><summary>Generated llms.txt</summary>
<p>

```
# Apache ECharts Documentation

> Apache ECharts is a free, powerful charting and visualization library offering easy ways to add intuitive, interactive, and highly customizable charts to your commercial products.

## API

- [api](llms-documents/api.md)
- [api.action](llms-documents/api-parts/api.action.md)
- [api.echarts](llms-documents/api-parts/api.echarts.md)
- [api.echartsInstance](llms-documents/api-parts/api.echartsInstance.md)
- [api.events](llms-documents/api-parts/api.events.md)

## Option GL

- [option-gl](llms-documents/option-gl.md)
- [option-gl.geo3D](llms-documents/option-gl-parts/option-gl.geo3D.md)
- [option-gl.globe](llms-documents/option-gl-parts/option-gl.globe.md)
- [option-gl.grid3D](llms-documents/option-gl-parts/option-gl.grid3D.md)
- [option-gl.mapbox3D](llms-documents/option-gl-parts/option-gl.mapbox3D.md)
- [option-gl.series-bar3D](llms-documents/option-gl-parts/option-gl.series-bar3D.md)
- [option-gl.series-flowGL](llms-documents/option-gl-parts/option-gl.series-flowGL.md)
- [option-gl.series-graphGL](llms-documents/option-gl-parts/option-gl.series-graphGL.md)
- [option-gl.series-line3D](llms-documents/option-gl-parts/option-gl.series-line3D.md)
- [option-gl.series-lines3D](llms-documents/option-gl-parts/option-gl.series-lines3D.md)
- [option-gl.series-map3D](llms-documents/option-gl-parts/option-gl.series-map3D.md)
- [option-gl.series-polygons3D](llms-documents/option-gl-parts/option-gl.series-polygons3D.md)
- [option-gl.series-scatter3D](llms-documents/option-gl-parts/option-gl.series-scatter3D.md)
- [option-gl.series-scatterGL](llms-documents/option-gl-parts/option-gl.series-scatterGL.md)
- [option-gl.series-surface](llms-documents/option-gl-parts/option-gl.series-surface.md)
- [option-gl.xAxis3D](llms-documents/option-gl-parts/option-gl.xAxis3D.md)
- [option-gl.yAxis3D](llms-documents/option-gl-parts/option-gl.yAxis3D.md)
- [option-gl.zAxis3D](llms-documents/option-gl-parts/option-gl.zAxis3D.md)

## Option

- [option](llms-documents/option.md)
- [option.angleAxis](llms-documents/option-parts/option.angleAxis.md)
- [option.aria](llms-documents/option-parts/option.aria.md)
- [option.axisPointer](llms-documents/option-parts/option.axisPointer.md)
- [option.brush](llms-documents/option-parts/option.brush.md)
- [option.calendar](llms-documents/option-parts/option.calendar.md)
- [option.dataset](llms-documents/option-parts/option.dataset.md)
- [option.dataZoom-inside](llms-documents/option-parts/option.dataZoom-inside.md)
- [option.dataZoom-slider](llms-documents/option-parts/option.dataZoom-slider.md)
- [option.geo](llms-documents/option-parts/option.geo.md)
- [option.graphic](llms-documents/option-parts/option.graphic.md)
- [option.grid](llms-documents/option-parts/option.grid.md)
- [option.legend](llms-documents/option-parts/option.legend.md)
- [option.matrix](llms-documents/option-parts/option.matrix.md)
- [option.media](llms-documents/option-parts/option.media.md)
- [option.parallel](llms-documents/option-parts/option.parallel.md)
- [option.parallelAxis](llms-documents/option-parts/option.parallelAxis.md)
- [option.polar](llms-documents/option-parts/option.polar.md)
- [option.radar](llms-documents/option-parts/option.radar.md)
- [option.radiusAxis](llms-documents/option-parts/option.radiusAxis.md)
- [option.series-bar](llms-documents/option-parts/option.series-bar.md)
- [option.series-boxplot](llms-documents/option-parts/option.series-boxplot.md)
- [option.series-candlestick](llms-documents/option-parts/option.series-candlestick.md)
- [option.series-chord](llms-documents/option-parts/option.series-chord.md)
- [option.series-custom](llms-documents/option-parts/option.series-custom.md)
- [option.series-effectScatter](llms-documents/option-parts/option.series-effectScatter.md)
- [option.series-funnel](llms-documents/option-parts/option.series-funnel.md)
- [option.series-gauge](llms-documents/option-parts/option.series-gauge.md)
- [option.series-graph](llms-documents/option-parts/option.series-graph.md)
- [option.series-heatmap](llms-documents/option-parts/option.series-heatmap.md)
- [option.series-line](llms-documents/option-parts/option.series-line.md)
- [option.series-lines](llms-documents/option-parts/option.series-lines.md)
- [option.series-map](llms-documents/option-parts/option.series-map.md)
- [option.series-parallel](llms-documents/option-parts/option.series-parallel.md)
- [option.series-pictorialBar](llms-documents/option-parts/option.series-pictorialBar.md)
- [option.series-pie](llms-documents/option-parts/option.series-pie.md)
- [option.series-radar](llms-documents/option-parts/option.series-radar.md)
- [option.series-sankey](llms-documents/option-parts/option.series-sankey.md)
- [option.series-scatter](llms-documents/option-parts/option.series-scatter.md)
- [option.series-sunburst](llms-documents/option-parts/option.series-sunburst.md)
- [option.series-themeRiver](llms-documents/option-parts/option.series-themeRiver.md)
- [option.series-tree](llms-documents/option-parts/option.series-tree.md)
- [option.series-treemap](llms-documents/option-parts/option.series-treemap.md)
- [option.singleAxis](llms-documents/option-parts/option.singleAxis.md)
- [option.stateAnimation](llms-documents/option-parts/option.stateAnimation.md)
- [option.textStyle](llms-documents/option-parts/option.textStyle.md)
- [option.thumbnail](llms-documents/option-parts/option.thumbnail.md)
- [option.timeline](llms-documents/option-parts/option.timeline.md)
- [option.title](llms-documents/option-parts/option.title.md)
- [option.toolbox](llms-documents/option-parts/option.toolbox.md)
- [option.tooltip](llms-documents/option-parts/option.tooltip.md)
- [option.visualMap-continuous](llms-documents/option-parts/option.visualMap-continuous.md)
- [option.visualMap-piecewise](llms-documents/option-parts/option.visualMap-piecewise.md)
- [option.xAxis](llms-documents/option-parts/option.xAxis.md)
- [option.yAxis](llms-documents/option-parts/option.yAxis.md)

## Handbook

- [ECharts Handbook](https://echarts.apache.org/handbook/en/get-started)
```

</p>
</details> 

## Approach

As a simple approach, this links to `/handbook/{lang}/get-started` rather than generating LLM-specific docs from the handbook content. 
Since the handbook is a static site, LLMs can fetch the HTML pages directly. 
Note: linking directly to HTML pages from llms.txt is a pattern also used by others (e.g. [Vercel](https://vercel.com/llms.txt)). 

Some alternatives I considered for improvement:

### Option 1: List all handbook page URLs in echarts-doc's llms.txt

Auto-syncing seems difficult, but given the handbook doesn't change frequently, manual maintenance might be acceptable.

`/en/llms.txt`:
```
- [Get Started](https://echarts.apache.org/handbook/en/get-started)
- [Basic Bar Chart](https://echarts.apache.org/handbook/en/how-to/chart-types/bar/basic-bar)
- [Style Customization](https://echarts.apache.org/handbook/en/concepts/style)
- ...
```

### Option 2: Add llms.txt to the echarts-handbook repo (HTML URLs)

The handbook repo owns its own llms.txt listing all page URLs. echarts-doc's llms.txt just links to it. Clean separation, but requires changes in the handbook repo.

`/en/llms.txt` (echarts-doc):
```
- [ECharts Handbook](https://echarts.apache.org/handbook/en/llms.txt)
```

`/handbook/en/llms.txt` (echarts-handbook):
```
- [Get Started](https://echarts.apache.org/handbook/en/get-started)
- [Style Customization](https://echarts.apache.org/handbook/en/concepts/style)
- ...
```

### Option 3: Add llms.txt to the echarts-handbook repo (with Markdown generation)

Same as above, but also converts handbook pages to LLM-friendly Markdown. Best LLM experience, but more build complexity in the handbook repo. (The handbook source is already clean Markdown, so conversion might be minimal — template variable replacement.)  

`/handbook/en/llms.txt` (echarts-handbook):
```
- [Get Started](llms-documents/get-started.md)
- [Style Customization](llms-documents/concepts/style.md)
- ...                                                                                                                                                 
```

 Would appreciate any thoughts on the preferred direction, or happy to keep it simple as-is for now!   