### PR TITLE
docs(option): document missing option properties

### DIFF
--- a/en/option/component/data-zoom-slider.md
+++ b/en/option/component/data-zoom-slider.md
@@ -225,10 +225,13 @@ Whether to update view while dragging. If it is set as `false`, the view will be
 
 ## textStyle(*)
 
-{{ use: partial-simple-text-style(
+{{ use: partial-text-style(
     prefix = '##',
     name = 'dataZoom ',
-    defaultColor = '#333'
+    defaultColor = '#333',
+    noAlign = true,
+    noVerticalAlign = true,
+    noRich = true
 ) }}
 
 {{ use: partial-data-zoom-common(
@@ -321,4 +324,3 @@ Whether to show the label.
 {{ use: partial-item-style(
     prefix = "###"
 ) }}
-

--- a/en/option/component/grid.md
+++ b/en/option/component/grid.md
@@ -118,6 +118,14 @@ See also [outerBounds example](${galleryEditorPath}doc-example/grid-outerBounds&
     needShow = true
 ) }}
 
+## opacity(number) = 1
+
+<ExampleUIControlNumber min="0" max="1" step="0.01" default="1" />
+
+Opacity of grid background and border.
+
+**Attention**: Works only if `show: true` is set.
+
 {{ use: partial-tooltip-in-coords() }}
 
 {{ use: partial-coord-sys(

--- a/en/option/component/toolbox.md
+++ b/en/option/component/toolbox.md
@@ -100,6 +100,12 @@ A group of utility tools, which includes [export](~toolbox.feature.saveAsImage),
 
 Whether to show toolbox component.
 
+## backgroundColor(Color) = 'transparent'
+
+<ExampleUIControlColor default="transparent" />
+
+Background color of toolbox component.
+
 ## orient(string) = 'horizontal'
 
 <ExampleUIControlEnum options="vertical,horizontal" />
@@ -559,4 +565,3 @@ option = {
     ...
 }
 ```
-

--- a/en/option/partial/2d-data.md
+++ b/en/option/partial/2d-data.md
@@ -51,6 +51,10 @@ Check this [example](${galleryEditorPath}dataset-series-layout-by).
 
 If [series.data](~series.data) is not specified, and [dataset](~dataset) exists, the series will use `dataset`. `datasetIndex` specifies which dataset will be used.
 
+## datasetId(string|number)
+
+If [series.data](~series.data) is not specified, and [dataset](~dataset) exists, the series will use `dataset`. `datasetId` specifies which dataset will be used by the `id` of the dataset.
+
 
 
 {{ target: partial-2d-data-desc }}
@@ -183,4 +187,3 @@ When needing to customize a data item, it can be set as an object, where propert
 For example, line chart can break when encounter an empty value, and scatter chart do not display graphic elements for empty values.
 
 <br><br>
-

--- a/en/option/partial/encode-dimensions.md
+++ b/en/option/partial/encode-dimensions.md
@@ -100,7 +100,6 @@ encode: {
 
 This is an [example](${galleryViewPath}dataset-encode1&edit=1&reset=1) for `encode`.
 
-
 Specially, in [custom series(~series-custom), some property in `encode`, corresponding to axis, can be set as null to make the series not controlled by the axis, that is, the series data will not be count in the extent of the axis, and the [dataZoom](~dataZoom) on the axis will not filter the series.
 
 
@@ -138,6 +137,14 @@ var option = {
     }
 };
 ```
+
+##${prefix} label(string|number|Array)
+
+Specify the dimension or dimensions used for the default label content.
+
+##${prefix} itemName(string|number|Array)
+
+Specify the dimension used as the data item name. The name is used by default labels and tooltips. For series whose legend represents data items, such as `pie` and `funnel`, it is also used as the legend item name.
 
 
 
@@ -197,4 +204,3 @@ Each data item of `dimensions` can be:
     + displayName: `string`, generally used in tooltip for dimension display. If not specified, use `name` by default.
 
 When `dimensions` is specified, the default `tooltip` will be displayed vertically, which is better to show dimension names. Otherwise, `tooltip` will displayed only value horizontally.
-

--- a/en/option/partial/tooltip-common.md
+++ b/en/option/partial/tooltip-common.md
@@ -193,6 +193,23 @@ It is valid when [axisPointer.type](~tooltip.axisPointer.type) is `'cross'`.
 
 {{ target: partial-tooltip-common }}
 
+{{ if: ${scope} === 'series' || ${scope} === 'seriesData' }}
+#${prefix} show(boolean) = true
+
+Whether to show the tooltip.
+
+{{ /if }}
+{{ if: ${scope} === 'series' }}
+#${prefix} trigger(string|boolean) = 'item'
+
+Override the tooltip trigger type for this series.
+
+Options:
++ `'item'`
++ `'axis'`
++ `'none'` or `false`: Do not trigger tooltip in this series.
+
+{{ /if }}
 #${prefix} position(string|Array)
 
 {{ use: partial-tooltip-scope-tip(

--- a/en/option/partial/zr-graphic.md
+++ b/en/option/partial/zr-graphic.md
@@ -316,6 +316,10 @@ When [overflow](~${optionPath}.${hostName}${symbolVisit}text.style.overflow) is 
 
 Text vertical alignment. Optional values: `'top'`, `'middle'`, `'bottom'`.
 
+###${prefix} rich(Object)
+
+Rich text styles. The key is the style name, and the value is the style definition for that rich text fragment.
+
 {{ use: partial-graphic-cpt-style-prop-common(
     prefix = ${prefix},
     optionPath = ${optionPath},
@@ -2193,4 +2197,3 @@ Although the points will be interpolated, the consequent animation will be like 
 ```
 
 See this example [example](${galleryEditorPath}custom-spiral-race&edit=1&reset=1).
-

--- a/en/option/series/graph.md
+++ b/en/option/series/graph.md
@@ -550,6 +550,8 @@ Select state of specified edge.
     state = 'select'
 ) }}
 
+{{ use: partial-tooltip-in-series-data() }}
+
 ### symbol(Array|string)
 
 Symbol of edge ends. Can be an array with two item to specify two ends, or a string specifies both ends.

--- a/en/option/series/heatmap.md
+++ b/en/option/series/heatmap.md
@@ -134,6 +134,10 @@ Configurations of select state. Available when [selectedMode](~series-heatmap.se
     prefix = "#"
 ) }}
 
+{{ use: partial-series-dimensions(
+    prefix = "#"
+) }}
+
 {{ use: partial-seriesLayoutBy() }}
 
 {{ use: partial-datasetIndex() }}
@@ -240,4 +244,3 @@ Style of a single data point. It is valid with [coordinateSystem](~series-heatma
 {{ use: partial-universal-transition(
     prefix = "#"
 ) }}
-

--- a/en/option/series/pie.md
+++ b/en/option/series/pie.md
@@ -168,7 +168,9 @@ Style of circle placeholder.
     prefix = "##",
     position = true,
     formatter = true,
-    labelMargin = true
+    labelMargin = true,
+    defaultShowLabel = true,
+    silent = true
 ) }}
 
 ### alignTo(string) = 'none'
@@ -483,8 +485,14 @@ Animation type when data updates.
 
 {{ target: partial-pie-label }}
 
-#${prefix} show(boolean) = false
+#${prefix} show(boolean) = ${defaultShowLabel|default("false")}
 
+{{ if: ${silent} }}
+#${prefix} silent(boolean) = false
+
+Whether to ignore mouse events. Default value is `false`, for triggering and responding to mouse events.
+
+{{ /if }}
 {{ if: ${position} }}
 #${prefix} position(string) = 'outside'
 
@@ -573,4 +581,3 @@ Label rotation.
     prefix = "#" + ${prefix},
     type = "pie"
 ) }}
-

--- a/en/option/series/sankey.md
+++ b/en/option/series/sankey.md
@@ -342,7 +342,8 @@ The lable style of this node.
 
 {{ use: partial-label(
     prefix = "###",
-    labelMargin = true
+    labelMargin = true,
+    formatter1d = true
 ) }}
 
 ### emphasis(Object)
@@ -454,6 +455,8 @@ The value of edge, which decides the width of edge.
     prefix = "###",
     state = "select"
 ) }}
+
+{{ use: partial-tooltip-in-series-data() }}
 
 ## edges(Array)
 

--- a/en/option/series/tree.md
+++ b/en/option/series/tree.md
@@ -331,6 +331,10 @@ The name of the tree node, used to identify each node.
 
 The value of the node, displayed in the tooltip.
 
+### children(Array)
+
+The children nodes defined recursively. The structure is the same as [series-tree.data](~series-tree.data).
+
 ### collapsed(boolean)
 
 Whether to collapse node at initialization.

--- a/zh/option/component/data-zoom-slider.md
+++ b/zh/option/component/data-zoom-slider.md
@@ -255,10 +255,13 @@ labelFormatter: function (value) {
 
 ## textStyle(Object)
 
-{{ use: partial-simple-text-style(
+{{ use: partial-text-style(
     prefix = '##',
     name = 'dataZoom ',
-    defaultColor = '#333'
+    defaultColor = '#333',
+    noAlign = true,
+    noVerticalAlign = true,
+    noRich = true
 ) }}
 
 {{ use: partial-data-zoom-common(
@@ -353,4 +356,3 @@ dataZoom-slider 组件的高度。水平布局默认 30，竖直布局默认自�
 {{ use: partial-item-style(
     prefix = "###"
 ) }}
-

--- a/zh/option/component/grid.md
+++ b/zh/option/component/grid.md
@@ -154,6 +154,14 @@ grid 区域是否包含坐标轴的[刻度标签](~yAxis.axisLabel)。
     needShow = true
 ) }}
 
+## opacity(number) = 1
+
+<ExampleUIControlNumber min="0" max="1" step="0.01" default="1" />
+
+直角坐标系网格背景和边框的透明度。
+
+**注意**：此配置项生效的前提是，设置了 `show: true`。
+
 {{ use: partial-tooltip-in-coords() }}
 
 {{ use: partial-coord-sys(

--- a/zh/option/component/toolbox.md
+++ b/zh/option/component/toolbox.md
@@ -174,6 +174,12 @@ option = {
 
 是否显示工具栏组件。
 
+## backgroundColor(Color) = 'transparent'
+
+<ExampleUIControlColor default="transparent" />
+
+工具栏组件的背景色。
+
 ## orient(string) = 'horizontal'
 
 <ExampleUIControlEnum options="vertical,horizontal" />
@@ -631,4 +637,3 @@ option = {
     ...
 }
 ```
-

--- a/zh/option/partial/2d-data.md
+++ b/zh/option/partial/2d-data.md
@@ -49,6 +49,10 @@ formatter: '{b}: {@score}'
 
 如果 [series.data](~series.data) 没有指定，并且 [dataset](~dataset) 存在，那么就会使用 [dataset](~dataset)。`datasetIndex` 指定本系列使用哪个 [dataset](~dataset)。
 
+## datasetId(string|number)
+
+如果 [series.data](~series.data) 没有指定，并且 [dataset](~dataset) 存在，那么就会使用 [dataset](~dataset)。`datasetId` 通过 dataset 的 `id` 指定本系列使用哪个 [dataset](~dataset)。
+
 
 
 {{ target: partial-2d-data-desc }}
@@ -171,4 +175,3 @@ series: [{
 当某数据不存在时（ps：*不存在*不代表值为 0），可以用 `'-'` 或者 `null` 或者 `undefined` 或者 `NaN` 表示。
 
 例如，无数据在折线图中可表现为该点是断开的，在其它图中可表示为图形不存在。
-

--- a/zh/option/partial/encode-dimensions.md
+++ b/zh/option/partial/encode-dimensions.md
@@ -95,8 +95,6 @@ encode: {
 
 这是个更丰富的 `encode` 的[示例](${galleryViewPath}dataset-encode1&edit=1&reset=1)：
 
-
-
 特殊地，在 [自定义系列（custom series）](~series-custom) 中，`encode` 中轴可以不指定或设置为 `null/undefined`，从而使系列免于受这个轴控制，也就是说，轴的范围（extent）不会受此系列数值的影响，轴被 [dataZoom](~dataZoom) 控制时也不会过滤掉这个系列：
 
 ```ts
@@ -133,6 +131,14 @@ var option = {
     }
 };
 ```
+
+##${prefix} label(string|number|Array)
+
+指定默认标签内容使用的维度。
+
+##${prefix} itemName(string|number|Array)
+
+指定作为数据项名称的维度。该名称会用于默认标签和提示框。对于饼图、漏斗图等图例项表示数据项的系列，该名称也会作为图例项名称。
 
 
 
@@ -192,4 +198,3 @@ series: {
     + displayName: 一般用于 tooltip 中维度名的展示。`string` 如果没有指定，默认使用 name 来展示。
 
 值得一提的是，当定义了 `dimensions` 后，默认 `tooltip` 中对个维度的显示，会变为『竖排』，从而方便显示每个维度的名称。如果没有定义 `dimensions`，则默认 `tooltip` 会横排显示，且只显示数值没有维度名称可显示。
-

--- a/zh/option/partial/tooltip-common.md
+++ b/zh/option/partial/tooltip-common.md
@@ -196,6 +196,23 @@
 
 {{ target: partial-tooltip-common }}
 
+{{ if: ${scope} === 'series' || ${scope} === 'seriesData' }}
+#${prefix} show(boolean) = true
+
+是否显示提示框。
+
+{{ /if }}
+{{ if: ${scope} === 'series' }}
+#${prefix} trigger(string|boolean) = 'item'
+
+覆盖本系列的提示框触发类型。
+
+可选值：
++ `'item'`
++ `'axis'`
++ `'none'` 或 `false`：不触发本系列提示框。
+
+{{ /if }}
 #${prefix} position(string|Array|Function)
 
 {{ use: partial-tooltip-scope-tip(

--- a/zh/option/partial/zr-graphic.md
+++ b/zh/option/partial/zr-graphic.md
@@ -316,6 +316,10 @@ font: 'bolder 2em "Microsoft YaHei", sans-serif'
 
 垂直对齐方式，取值：`'top'`, `'middle'`, `'bottom'`。
 
+###${prefix} rich(Object)
+
+富文本样式。键名为样式名，值为对应富文本片段的样式定义。
+
 {{ use: partial-graphic-cpt-style-prop-common(
     prefix = ${prefix},
     optionPath = ${optionPath},
@@ -2167,4 +2171,3 @@ type TransformProp =
 ```
 
 也参见这个 [例子](${galleryEditorPath}custom-spiral-race&edit=1&reset=1)。
-

--- a/zh/option/series/graph.md
+++ b/zh/option/series/graph.md
@@ -587,6 +587,8 @@ links: [{
     state = 'select'
 ) }}
 
+{{ use: partial-tooltip-in-series-data() }}
+
 ### symbol(Array|string)
 
 边两端的标记类型，可以是一个数组分别指定两端，也可以是单个统一指定。

--- a/zh/option/series/heatmap.md
+++ b/zh/option/series/heatmap.md
@@ -185,6 +185,10 @@ option = {
     prefix = "#"
 ) }}
 
+{{ use: partial-series-dimensions(
+    prefix = "#"
+) }}
+
 {{ use: partial-seriesLayoutBy() }}
 
 {{ use: partial-datasetIndex() }}
@@ -291,4 +295,3 @@ option = {
 {{ use: partial-universal-transition(
     prefix = "#"
 ) }}
-

--- a/zh/option/series/pie.md
+++ b/zh/option/series/pie.md
@@ -191,7 +191,9 @@ const option = {
     prefix = "##",
     position = true,
     formatter = true,
-    labelMargin = true
+    labelMargin = true,
+    defaultShowLabel = true,
+    silent = true
 ) }}
 
 ### alignTo(string) = 'none'
@@ -506,8 +508,14 @@ const option = {
 
 {{ target: partial-pie-label }}
 
-#${prefix} show(boolean) = false
+#${prefix} show(boolean) = ${defaultShowLabel|default("false")}
 
+{{ if: ${silent} }}
+#${prefix} silent(boolean) = false
+
+是否忽略鼠标事件。默认值为 `false`，即响应和触发鼠标事件。
+
+{{ /if }}
 {{ if: ${position} }}
 #${prefix} position(string) = 'outside'
 
@@ -596,4 +604,3 @@ const option = {
     prefix = "#" + ${prefix},
     type = "饼图"
 ) }}
-

--- a/zh/option/series/sankey.md
+++ b/zh/option/series/sankey.md
@@ -345,7 +345,8 @@ data: [{
 
 {{ use: partial-label(
     prefix = "###",
-    labelMargin = true
+    labelMargin = true,
+    formatter1d = true
 ) }}
 
 ### emphasis(Object)
@@ -457,6 +458,8 @@ links: [{
     prefix = "###",
     state = "select"
 ) }}
+
+{{ use: partial-tooltip-in-series-data() }}
 
 ## edges(Array)
 

--- a/zh/option/series/tree.md
+++ b/zh/option/series/tree.md
@@ -373,6 +373,10 @@ const option = {
 
 节点的值，在 tooltip 中显示。
 
+### children(Array)
+
+递归定义的子节点，结构同 [series-tree.data](~series-tree.data)。
+
 ### collapsed(boolean)
 
 节点初始化是否折叠。


### PR DESCRIPTION
## Summary
- document `toolbox.backgroundColor` in English and Chinese option docs
- expand `dataZoom-slider.textStyle` docs to include supported text box styles while keeping unsupported `align`, `verticalAlign`, and `rich` hidden
- document recursive `children` for `series-tree.data` items
- document additional confirmed missing option docs: `datasetId`, `grid.opacity`, `series.tooltip.show`, `series.tooltip.trigger`, `series.data.tooltip.show`, `series-bar.encode.label`, `series-pie.encode.itemName`, `series-heatmap.dimensions`, `series-graph.links.tooltip`, `series-sankey.links.tooltip`, `series-sankey.data.label.formatter`, `series-custom.renderItem.return_text.style.rich`, and `series-pie.label.silent`
- correct the generated default for `series-pie.label.show` to `true`

## Not included
- `option.textStyle.backgroundColor`: not documented because `GlobalTextStyleOption` in ECharts source does not support `backgroundColor`
- `dataZoom-slider.dataBackgroundColor`: not documented because it is a deprecated legacy option; `borderColor` is the current documented option
- `series-pie.label.textStyle`: not documented because `textStyle` under `label` is a deprecated compatibility hierarchy that is flattened by the preprocessor; current docs already document the flattened `label` style properties
- `series-custom.label`: not documented because it is marked `@deprecated` in `CustomSeriesOption`
- `series-candlestick.markArea.label.formatter` and `series-scatter.markArea.data.0.label.formatter`: not changed because both are already generated in the option schema
- The `calendar` heatmap `encode` behavior mentioned in apache/echarts#20748 is a runtime issue and is not addressed here; this PR only documents the supported `series-heatmap.dimensions` option

## Verification
- `npm run build`
- `git diff --check`
- source-schema checks for en/zh option docs confirmed the newly documented paths are generated, including `grid.opacity`, `series.datasetId`, `series.tooltip.trigger`, `series.data.tooltip.show`, `series-bar.encode.label`, `series-pie.encode.itemName`, `series-heatmap.dimensions`, `series-graph.links.tooltip.show`, `series-sankey.links.tooltip.show`, `series-sankey.data.label.formatter`, `series-custom.renderItem.return_text.style.rich`, `series-pie.label.silent`, and `series-pie.label.show` with default `true`

Fixes apache/echarts#21643