### PR TITLE
docs(axisPointer): document `triggerOnNoData` and  `findPointOnConnectedCharts`

### DIFF
--- a/en/option/component/axisPointer.md
+++ b/en/option/component/axisPointer.md
@@ -118,3 +118,15 @@ Conditions to trigger tooltip. Options:
 
     Do not triggered by `'mousemove'` and `'click'`
 
+## findPointOnConnectedCharts(boolean) = true
+
+<ExampleUIControlBoolean default="true" />
+
+{{ use: partial-version(
+    version = "6.2.0"
+) }}
+
+When an action is dispatched to a chart linked by [echarts.connect](api.html#echarts.connect), the original pixel position is meaningless on the receiving chart. By default ECharts then picks a sample point from that chart's own series to place the axis pointer and tooltip.
+
+Set this to `false` to skip that lookup, so the axis pointer follows the linked axis value (see [triggerOnNoData](~xAxis.axisPointer.triggerOnNoData)) instead of snapping to a sample data point.
+

--- a/en/option/partial/axisPointer-common.md
+++ b/en/option/partial/axisPointer-common.md
@@ -116,6 +116,20 @@ Whether to trigger emphasis of series.
 
 Whether to trigger tooltip.
 
+#${prefix} triggerOnNoData(boolean) = false
+
+<ExampleUIControlBoolean default="false" />
+
+{{ use: partial-version(
+    version = "6.2.0"
+) }}
+
+Whether to keep the axis pointer shown when there is no data at the pointed position.
+
+This is mainly useful for charts linked by [echarts.connect](api.html#echarts.connect). When you hover over one chart at a position where another linked chart has no data, that chart's axis pointer would normally be hidden; with this turned on it stays visible at the linked axis value instead.
+
+Note that the axis still needs a determined range (for example a fixed `min`/`max`), so that a value exists at positions without data.
+
 #${prefix} value(number) = null
 
 current value. When using [axisPointer.handle](xAxisPointer.handle), `value` can be set to define the initial position of axisPointer.

--- a/zh/option/component/axisPointer.md
+++ b/zh/option/component/axisPointer.md
@@ -219,3 +219,15 @@ mapper 的返回值：
 
     不在 `'mousemove'` 或 `'click'` 时触发。
 
+## findPointOnConnectedCharts(boolean) = true
+
+<ExampleUIControlBoolean default="true" />
+
+{{ use: partial-version(
+    version = "6.2.0"
+) }}
+
+当某个操作被分发到通过 [echarts.connect](api.html#echarts.connect) 关联的图表时，原始的像素坐标在接收图表上没有意义。此时 ECharts 默认会从该图表自身的系列中挑选一个采样点，用于定位坐标轴指示器和 tooltip。
+
+设置为 `false` 可跳过该查找，使坐标轴指示器跟随关联的轴值（参见 [triggerOnNoData](~xAxis.axisPointer.triggerOnNoData)），而不会吸附到某个采样数据点。
+

--- a/zh/option/partial/axisPointer-common.md
+++ b/zh/option/partial/axisPointer-common.md
@@ -111,6 +111,20 @@ axisPointer 的 label 默认不显示（也就是默认只显示指示线），�
 
 是否触发 tooltip。如果不想触发 tooltip 可以关掉。
 
+#${prefix} triggerOnNoData(boolean) = false
+
+<ExampleUIControlBoolean default="false" />
+
+{{ use: partial-version(
+    version = "6.2.0"
+) }}
+
+当指示位置没有数据时，是否仍然显示坐标轴指示器。
+
+该配置主要用于通过 [echarts.connect](api.html#echarts.connect) 关联的图表。当鼠标悬浮在某个图表上、而另一个关联图表在该位置没有数据时，那个图表的坐标轴指示器原本会被隐藏；开启该配置后，它会继续显示在关联的轴值处。
+
+注意，坐标轴本身仍然需要有确定的范围（例如固定的 `min`/`max`），这样在没有数据的位置才有对应的轴值。
+
 #${prefix} value(number) = null
 
 当前的 value。在使用 [axisPointer.handle](xAxisPointer.handle) 时，可以设置此值进行初始值设定，从而决定 axisPointer 的初始位置。


### PR DESCRIPTION
Documents two new `axisPointer` options added in apache/echarts#21656.

### Options

- **`axisPointer.triggerOnNoData`** (`boolean`, default `false`) — when enabled, the axis pointer stays visible at a position even if there is no data there. Mainly useful for charts linked by `echarts.connect`: hovering one chart where a connected chart has no data keeps the pointer shown on the other chart at the linked axis value instead of hiding it.
- **`axisPointer.findPointOnConnectedCharts`** (`boolean`, default `true`) — set to `false` to stop a connected chart from snapping the pointer to a sample series point, so it follows the linked axis value only.

### Where

- `triggerOnNoData` goes in the shared `option/partial/axisPointer-common.md`, so it is documented once and shown across all axisPointer contexts (x/y/radius/ angle/single/parallel axes, the `axisPointer` component, and `tooltip.axisPointer`).
- `findPointOnConnectedCharts` goes in `option/component/axisPointer.md`, since the code reads it from the top-level `axisPointer` component only.

Both options are documented in English and Chinese, tagged `Since v6.2.0` (please adjust if the release version differs).

### Related

- Code PR: apache/echarts#21656

### Verification

Ran `node build/build-doc.js --env asf`; the option markdown parses and both options render into `option.json` (en + zh) with the version badge, the `echarts.connect` link, and the `triggerOnNoData` cross-reference.
