### PR TITLE
docs: 修复文档错误

### DIFF
--- a/en/api/echarts.md
+++ b/en/api/echarts.md
@@ -107,7 +107,7 @@ Returns chart instance of dom container.
 
 Use components. Used with the new tree-shaking API.
 
-NOTE: `echarts.use` must be used before `eharts.init`
+NOTE: `echarts.use` must be used before `echarts.init`
 
 ```ts
 // Import the echarts core module, which provides the necessary interfaces for using echarts.

--- a/en/option/component/timeline.md
+++ b/en/option/component/timeline.md
@@ -535,13 +535,13 @@ Rotation angle of `label`, in which positive values refer to counter clockwise r
 {{ if: ${state} }}
 {{ use: partial-text-style(
     prefix = ${prefix},
-    name = "timeline.lable." + ${state},
+    name = "timeline.label." + ${state},
     defaultColor = ${textStyleDefaultColor}
 ) }}
 {{ else }}
 {{ use: partial-text-style(
     prefix = ${prefix},
-    name = "timeline.lable",
+    name = "timeline.label",
     defaultColor = ${textStyleDefaultColor}
 ) }}
 {{ /if }}

--- a/zh/option/component/timeline.md
+++ b/zh/option/component/timeline.md
@@ -895,13 +895,13 @@ const option = {
 {{ if: ${state} }}
 {{ use: partial-text-style(
     prefix = ${prefix},
-    name = "timeline.lable." + ${state},
+    name = "timeline.label." + ${state},
     defaultColor = ${textStyleDefaultColor}
 ) }}
 {{ else }}
 {{ use: partial-text-style(
     prefix = ${prefix},
-    name = "timeline.lable",
+    name = "timeline.label",
     defaultColor = ${textStyleDefaultColor}
 ) }}
 {{ /if }}


### PR DESCRIPTION
## 修改内容
- 修正 `en/api/echarts.md` 中 `eharts.init` 拼写为 `echarts.init`
- 修正中英文 timeline 模板名 `timeline.lable` 为 `timeline.label`

## 验证
- `npm run build`